### PR TITLE
[CI] Fix handling of closed PR event

### DIFF
--- a/.github/workflows/previews-ods-ui.yaml
+++ b/.github/workflows/previews-ods-ui.yaml
@@ -21,12 +21,18 @@ jobs:
       pull-requests: write
 
     steps:
-      - name: Checkout
+      - name: Checkout branch
+        if: github.event.action != 'closed'
         uses: actions/checkout@v5
         # Fetch the full history for the branch to be able to get the short SHA
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
+
+      # If the PR is closed, the branch may be deleted already, so we can't checkout the branch
+      - name: Checkout
+        if: github.event.action == 'closed'
+        uses: actions/checkout@v5
 
       - name: Set up kubectl
         uses: azure/setup-kubectl@v4


### PR DESCRIPTION
The closed PR event action was failing because the branch was already removed.
We needed to get the branch for having the right SHA, but for removing the resources, we don't need the right value for the image tag.