### PR TITLE
piveau: set base IRI to opendata.swiss

### DIFF
--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       - 8085:8085
       - 5002:5000
     environment:
+      - PIVEAU_HUB_BASE_URI=https://opendata.swiss/
       - PIVEAU_HUB_SEARCH_SERVICE=${PIVEAU_HUB_SEARCH_SERVICE}
       - PIVEAU_HUB_API_KEY=${PIVEAU_HUB_API_KEY}
       - PIVEAU_HUB_SHELL_CONFIG={"http":{},"telnet":{}}


### PR DESCRIPTION
Without explicit configuration, piveau is using `https://piveau.io/` as base for RDF resource IRIs

This configuration sets the base to `https://opendata.swiss/`

So a catalog resource "kt-zh" will then get the IRI `https://opendata.swiss/id/catalogue/kt-zh

Further customization of the IRIs would be possible as well, if needed at some point:

https://gitlab.com/piveau/hub/piveau-hub-repo/-/blob/ea5f2c428ea4eeb51164c74433a0df7800eb8655/conf/config.sample.json#L17-25