### PR TITLE
ci: add status check

### DIFF
--- a/.github/workflows/previews-ods-ui.yaml
+++ b/.github/workflows/previews-ods-ui.yaml
@@ -39,6 +39,13 @@ jobs:
         with:
           version: v1.33.0
 
+      - name: Set pending status
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          context: Preview deployed
+          status: pending
+
       - name: Set up Kustomize
         uses: imranismail/setup-kustomize@v2
 
@@ -102,6 +109,14 @@ jobs:
             Your preview environment is deployed! 🚀
             **URL:** https://${{ steps.vars.outputs.branch }}.piveau-ln-preview.zazukoians.org/
             **Note:** It may take a few minutes for the DNS to propagate, the certificate to be generated and the preview to be reachable.
+
+      - name: Final status check
+        uses: myrotvorets/set-commit-status-action@v2.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          context: Preview deployed
+          status: success
+          targetUrl: https://${{ steps.vars.outputs.branch }}.piveau-ln-preview.zazukoians.org/
 
       - name: Delete manifests
         working-directory: ./opendata.swiss/ui/k8s


### PR DESCRIPTION
This adds a commit status for decap to display in its UI. See https://decapcms.org/docs/deploy-preview-links/

Also related: https://github.com/decaporg/decap-cms/discussions/7599