### PR TITLE
[Stack] Upgrade `piveau-consus-exporting-hub` to 6.0.1

### DIFF
--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -173,7 +173,7 @@ services:
       - ./piveau_scripts:/usr/verticles/scripts
 
   piveau-consus-exporting-hub:
-    image: registry.gitlab.com/piveau/consus/piveau-consus-exporting-hub:6.0.0
+    image: registry.gitlab.com/piveau/consus/piveau-consus-exporting-hub:6.0.1
     logging:
       options:
         max-size: "50m"


### PR DESCRIPTION
This upgrades the `piveau-consus-exporting-hub` service to 6.0.1, so that it has the same version as the deployed instance.