### PR TITLE
Add Piveau metrics

### DIFF
--- a/opendata.swiss/metadata/README.md
+++ b/opendata.swiss/metadata/README.md
@@ -17,6 +17,8 @@
 
 ## Local Stack
 
+### Start the stack
+
 It is possible to start a local stack, in order to quickly try changes locally.
 
 For this, you need to have Docker and Docker Compose installed.
@@ -29,20 +31,39 @@ Finally, you can start the stack with:
 docker compose up -d # You can ignore the `-d` to see the logs in real time
 ```
 
+> [!TIP]
+> In case your local device is low on disk space, you may want to skip the low space checks of ElasticSearch, by running the following command:
+>
+> ```sh
+> ./scripts/disable_es_disk_check.sh
+> ```
+
 You can open the UI at [http://localhost:8080](http://localhost:8080).
+
+### Create resources
+
+#### Vocabularies
+
+To add the custom vocabularies, run:
+
+```sh
+./scripts/vocabularies.sh
+```
+
+In case you want to remove them, run:
+
+```sh
+./scripts/vocabularies_delete.sh
+```
+
+To install the default vocabularies, open the shell at [http://localhost:8085/shell.html](http://localhost:8085/shell.html) and run `installVocabularies`.
+
+#### Catalogues and Harvesting
 
 To create the catalogues, run:
 
 ```sh
 ./scripts/catalogues.sh
-```
-
-To install the default vocabularies, open the shell at [http://localhost:8085/shell.html](http://localhost:8085/shell.html) and run `installVocabularies`.
-
-To add custom vocabularies, run:
-
-```sh
-./scripts/vocabularies.sh
 ```
 
 And to trigger a harvest, run:

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -208,7 +208,8 @@ services:
       - ./piveau_scripts:/usr/verticles/scripts
 
   piveau-consus-exporting-hub:
-    image: registry.gitlab.com/piveau/consus/piveau-consus-exporting-hub:6.0.5
+    # image: registry.gitlab.com/piveau/consus/piveau-consus-exporting-hub:6.0.5
+    image: registry.gitlab.com/piveau/consus/piveau-consus-exporting-hub:6.0.4
     restart: unless-stopped
     logging:
       options:

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -325,7 +325,7 @@ services:
     restart: unless-stopped
 
   piveau-metrics-validating-shacl:
-    image: registry.gitlab.com/piveau/metrics/piveau-metrics-validating-shacl:4.2.4
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-validating-shacl:4.4.0
     restart: unless-stopped
     logging:
       options:
@@ -353,7 +353,7 @@ services:
       - JAVA_OPTS=-Xms1g -Xmx2g
 
   piveau-metrics-cache:
-    image: registry.gitlab.com/piveau/metrics/piveau-metrics-cache:5.6.11
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-cache:5.8.2
     restart: unless-stopped
     logging:
       options:
@@ -368,7 +368,7 @@ services:
       - JAVA_OPTS=-Xms1g -Xmx2g
 
   piveau-metrics-dataset-similarities:
-    image: registry.gitlab.com/piveau/metrics/piveau-metrics-dataset-similarities:3.0.2
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-dataset-similarities:3.0.3
     restart: unless-stopped
     logging:
       options:
@@ -379,7 +379,7 @@ services:
       - JAVA_OPTS=-Xms1g -Xmx2g
 
   piveau-metrics-annotator:
-    image: registry.gitlab.com/piveau/metrics/piveau-metrics-annotator:2.0.7
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-annotator:2.1.3
     restart: unless-stopped
     logging:
       options:
@@ -388,7 +388,7 @@ services:
       - JAVA_OPTS=-Xms1g -Xmx2g
 
   piveau-metrics-accessibility:
-    image: registry.gitlab.com/piveau/metrics/piveau-metrics-accessibility:2.0.7
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-accessibility:2.1.7
     restart: unless-stopped
     logging:
       options:
@@ -400,7 +400,7 @@ services:
       - PIVEAU_PIPE_LOG_LEVEL=TRACE
 
   piveau-metrics-score:
-    image: registry.gitlab.com/piveau/metrics/piveau-metrics-score:3.2.0
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-score:3.2.2
     restart: unless-stopped
     logging:
       options:

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -23,7 +23,8 @@ services:
       - PIVEAU_HUB_SEARCH_SERVICE=${PIVEAU_HUB_SEARCH_SERVICE}
       - PIVEAU_HUB_API_KEY=${PIVEAU_HUB_API_KEY}
       - PIVEAU_HUB_SHELL_CONFIG={"http":{},"telnet":{}}
-      - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://mitmproxy:8888/repositories", "queryEndpoint":"/piveau", "queryAuthEndpoint":"/piveau/statements", "graphEndpoint":"/piveau/rdf-graphs/service", "graphAuthEndpoint":"/piveau/rdf-graphs/service"}
+      # - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://mitmproxy:8888/repositories", "queryEndpoint":"/piveau", "queryAuthEndpoint":"/piveau/statements", "graphEndpoint":"/piveau/rdf-graphs/service", "graphAuthEndpoint":"/piveau/rdf-graphs/service"}
+      - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://virtuoso:8890","clearGeoDataCatalogues":["*"]}
       - PIVEAU_HUB_AUTHORIZATION_PROCESS_DATA=${PIVEAU_HUB_AUTHORIZATION_PROCESS_DATA}
       - PIVEAU_HUB_VALIDATOR={"enabled":true,"metricsPipeName":"metrics","history":false}
       - JAVA_OPTS=-Xms1g -Xmx2g
@@ -104,64 +105,83 @@ services:
     volumes:
       - ./volumes/elasticsearch-data:/usr/share/elasticsearch/data
 
-  graphdb:
-    image: ontotext/graphdb:10.8.8
-    container_name: graphdb
-    restart: unless-stopped
+  virtuoso:
+    image: openlink/virtuoso-opensource-7:7.2.13-alpine
+    container_name: virtuoso
     logging:
       options:
         max-size: "50m"
     ports:
-      - 7200:7200
-    command:
-      - -Xms2g
-      - -Xmx5g
-      - -Ddefault.min.distinct.threshold=512m
-      - -Dgraphdb.health.minimal.free.storage.enabled=false
-      - -Dgraphdb.health.minimal.free.storage.asyncCheck=false
+      - 8890:8890
+      - 1111:1111
+    environment:
+      - DBA_PASSWORD=dba
+      - VIRT_PARAMETERS_NUMBEROFBUFFERS=170000
+      - VIRT_PARAMETERS_MAXDIRTYBUFFERS=130000
+      - VIRT_PARAMETERS_SERVERTHREADS=100
+      - VIRT_HTTPSERVER_SERVERTHREADS=100
+      - VIRT_HTTPSERVER_MAXCLIENTCONNECTIONS=100
     volumes:
-      - ./volumes/graphdb-data:/opt/graphdb/dist/data
+      - ./volumes/virtuoso-data:/database
 
-  graphdb-create-repo:
-    image: curlimages/curl:latest
-    container_name: graphdb-create-repo
-    restart: "no" # Just run once
-    depends_on:
-      graphdb:
-        condition: service_started
-    command:
-      - /config/setup.sh
-    volumes:
-      - ./config/graphdb:/config:ro
+  # graphdb:
+  #   image: ontotext/graphdb:10.8.8
+  #   container_name: graphdb
+  #   restart: unless-stopped
+  #   logging:
+  #     options:
+  #       max-size: "50m"
+  #   ports:
+  #     - 7200:7200
+  #   command:
+  #     - -Xms2g
+  #     - -Xmx5g
+  #     - -Ddefault.min.distinct.threshold=512m
+  #     - -Dgraphdb.health.minimal.free.storage.enabled=false
+  #     - -Dgraphdb.health.minimal.free.storage.asyncCheck=false
+  #   volumes:
+  #     - ./volumes/graphdb-data:/opt/graphdb/dist/data
 
-  mitmproxy:
-    image: mitmproxy/mitmproxy:12.1.1
-    container_name: mitmproxy
-    restart: unless-stopped
-    logging:
-      options:
-        max-size: "50m"
-    ports:
-      - 8888:8888
-      - 8889:8889
-    command:
-      - mitmweb
-      - --mode
-      - reverse:http://graphdb:7200/
-      - --listen-port
-      - "8888"
-      - --web-host
-      - "0.0.0.0"
-      - --web-port
-      - "8889"
-      - --set
-      - web_password=mitm
-      - -s
-      - /scripts/strip_timeout.py
-      - -s
-      - /scripts/digest_to_basic.py
-    volumes:
-      - ./config/mitmproxy:/scripts
+  # graphdb-create-repo:
+  #   image: curlimages/curl:latest
+  #   container_name: graphdb-create-repo
+  #   restart: "no" # Just run once
+  #   depends_on:
+  #     graphdb:
+  #       condition: service_started
+  #   command:
+  #     - /config/setup.sh
+  #   volumes:
+  #     - ./config/graphdb:/config:ro
+
+  # mitmproxy:
+  #   image: mitmproxy/mitmproxy:12.1.1
+  #   container_name: mitmproxy
+  #   restart: unless-stopped
+  #   logging:
+  #     options:
+  #       max-size: "50m"
+  #   ports:
+  #     - 8888:8888
+  #     - 8889:8889
+  #   command:
+  #     - mitmweb
+  #     - --mode
+  #     - reverse:http://graphdb:7200/
+  #     - --listen-port
+  #     - "8888"
+  #     - --web-host
+  #     - "0.0.0.0"
+  #     - --web-port
+  #     - "8889"
+  #     - --set
+  #     - web_password=mitm
+  #     - -s
+  #     - /scripts/strip_timeout.py
+  #     - -s
+  #     - /scripts/digest_to_basic.py
+  #   volumes:
+  #     - ./config/mitmproxy:/scripts
 
   #############################
   # docker-compose-consus.yml #
@@ -364,7 +384,8 @@ services:
     environment:
       - MONGODB_CONNECTION=mongodb://mongodb:27017
       - CACHE_APIKEY=yourCacheApiKey
-      - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://mitmproxy:8888/repositories", "queryEndpoint":"/piveau", "queryAuthEndpoint":"/piveau/statements", "graphEndpoint":"/piveau/rdf-graphs/service", "graphAuthEndpoint":"/piveau/rdf-graphs/service"}
+      # - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://mitmproxy:8888/repositories", "queryEndpoint":"/piveau", "queryAuthEndpoint":"/piveau/statements", "graphEndpoint":"/piveau/rdf-graphs/service", "graphAuthEndpoint":"/piveau/rdf-graphs/service"}
+      - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://virtuoso:8890","clearGeoDataCatalogues":["*"]}
       - CACHE_CORS_DOMAINS=["localhost"]
       - JAVA_OPTS=-Xms1g -Xmx2g
 

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -25,6 +25,7 @@ services:
       - PIVEAU_HUB_SHELL_CONFIG={"http":{},"telnet":{}}
       - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://mitmproxy:8888/repositories", "queryEndpoint":"/piveau", "queryAuthEndpoint":"/piveau/statements", "graphEndpoint":"/piveau/rdf-graphs/service", "graphAuthEndpoint":"/piveau/rdf-graphs/service"}
       - PIVEAU_HUB_AUTHORIZATION_PROCESS_DATA=${PIVEAU_HUB_AUTHORIZATION_PROCESS_DATA}
+      - PIVEAU_HUB_VALIDATOR={"enabled":true,"metricsPipeName":"metrics","history":false}
       - JAVA_OPTS=-Xms1g -Xmx2g
     volumes:
       - ./piveau_profile:/piv-profile:ro
@@ -116,6 +117,8 @@ services:
       - -Xms2g
       - -Xmx5g
       - -Ddefault.min.distinct.threshold=512m
+      - -Dgraphdb.health.minimal.free.storage.enabled=false
+      - -Dgraphdb.health.minimal.free.storage.asyncCheck=false
     volumes:
       - ./volumes/graphdb-data:/opt/graphdb/dist/data
 
@@ -307,6 +310,105 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  ##############################
+  # docker-compose-metrics.yml #
+  ##############################
+  mongodb:
+    image: mongo:6.0.13
+    restart: unless-stopped
+    volumes:
+      - ./volumes/mongodb-data:/data/db
+
+  quickchart:
+    image: ianw/quickchart:v1.8.1
+    restart: unless-stopped
+
+  piveau-metrics-validating-shacl:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-validating-shacl:4.2.4
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    ports:
+      - 8181:8080
+    environment:
+      - JAVA_OPTS=-Xms1g -Xmx2g
+      - PIVEAU_LOG_LEVEL=trace
+      - PIVEAU_PIPE_LOG_LEVEL=TRACE
+
+  piveau-metrics-reporter:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-reporter:4.0.5
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    ports:
+      - 8183:8080
+    environment:
+      - API_KEY=yourReporterApiKey
+      - QUICKCHART_ADDRESS=http://quickchart:3400/chart
+      - SCHEDULES=[{"languages":["en","de"],"cron":" 0 50 16 1/1 * ? * "},{"languages":["fr","it"],"cron":" 0 55 16 1/1 * ? * "},{"languages":["en","de"],"cron":" 1 0 0 ? * * * "}]
+      - CORS_DOMAINS=["localhost"]
+      - JAVA_OPTS=-Xms1g -Xmx2g
+
+  piveau-metrics-cache:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-cache:5.6.11
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    ports:
+      - 8185:8080
+    environment:
+      - MONGODB_CONNECTION=mongodb://mongodb:27017
+      - CACHE_APIKEY=yourCacheApiKey
+      - PIVEAU_TRIPLESTORE_CONFIG={"address":"http://mitmproxy:8888/repositories", "queryEndpoint":"/piveau", "queryAuthEndpoint":"/piveau/statements", "graphEndpoint":"/piveau/rdf-graphs/service", "graphAuthEndpoint":"/piveau/rdf-graphs/service"}
+      - CACHE_CORS_DOMAINS=["localhost"]
+      - JAVA_OPTS=-Xms1g -Xmx2g
+
+  piveau-metrics-dataset-similarities:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-dataset-similarities:3.0.2
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    ports:
+      - 8186:8080
+    environment:
+      - JAVA_OPTS=-Xms1g -Xmx2g
+
+  piveau-metrics-annotator:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-annotator:2.0.7
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    environment:
+      - JAVA_OPTS=-Xms1g -Xmx2g
+
+  piveau-metrics-accessibility:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-accessibility:2.0.7
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    environment:
+      - PIVEAU_ACCESSIBILITY_PERSISTENCE_CONFIG={"mongoDbClient":{"connection_string":"mongodb://mongodb:27017"},"collection":"datasets"}
+      - JAVA_OPTS=-Xms1g -Xmx2g
+      - PIVEAU_LOG_LEVEL=trace
+      - PIVEAU_PIPE_LOG_LEVEL=TRACE
+
+  piveau-metrics-score:
+    image: registry.gitlab.com/piveau/metrics/piveau-metrics-score:3.2.0
+    restart: unless-stopped
+    logging:
+      options:
+        max-size: "50m"
+    environment:
+      - JAVA_OPTS=-Xms1g -Xmx2g
+      - PIVEAU_LOG_LEVEL=trace
+      - PIVEAU_PIPE_LOG_LEVEL=TRACE
 
   ####################
   # Custom services  #

--- a/opendata.swiss/metadata/piveau_pipes/pipe-metrics.yaml
+++ b/opendata.swiss/metadata/piveau_pipes/pipe-metrics.yaml
@@ -1,0 +1,44 @@
+header:
+  id: 7dbcff70-6bd5-495a-b7a1-3c139f86533d
+  name: metrics
+  title: System Metrics
+  context: piveau
+  transport: payload
+  version: "2.0.0"
+body:
+  segments:
+    - header:
+        name: piveau-metrics-validating-shacl
+        segmentNumber: 1
+        title: Metrics SHACL validation
+        processed: false
+      body:
+        config: {}
+    - header:
+        name: piveau-metrics-annotator
+        segmentNumber: 2
+        title: Metrics annotations
+        processed: false
+      body:
+        config: {}
+    - header:
+        name: piveau-metrics-accessibility
+        segmentNumber: 3
+        title: Metrics accessibility
+        processed: false
+      body:
+        config: {}
+    - header:
+        name: piveau-metrics-score
+        segmentNumber: 4
+        title: Metrics scoring
+        processed: false
+      body:
+        config: {}
+    - header:
+        name: piveau-consus-exporting-hub
+        segmentNumber: 5
+        title: Exporting hub
+        processed: false
+      body:
+        config: {}

--- a/opendata.swiss/metadata/scripts/disable_es_disk_check.sh
+++ b/opendata.swiss/metadata/scripts/disable_es_disk_check.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -eu
+
+# Configure Elasticsearch to skip low disk space checks
+curl -X PUT "http://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "persistent": {
+      "cluster.routing.allocation.disk.threshold_enabled": false
+    }
+  }'
+
+# To check the current settings, you can use:
+curl -X GET "http://localhost:9200/_cluster/settings?pretty"

--- a/opendata.swiss/metadata/scripts/harvest.sh
+++ b/opendata.swiss/metadata/scripts/harvest.sh
@@ -14,5 +14,6 @@ else
   CURL_CREDS=""
 fi
 
-curl -i -X PUT -H 'Content-Type: application/json' $CURL_CREDS --data '{"status": "enabled", "id": "immediateTrigger"}' "${CONSUS_SCHEDULING_ENDPOINT}/pipes/staatskanzelei-kanton-zuerich/triggers/immediateTrigger"
+# We disable the trigger for Staatskanzlei Kanton Zürich as their endpoint seems to be broken
+# curl -i -X PUT -H 'Content-Type: application/json' $CURL_CREDS --data '{"status": "enabled", "id": "immediateTrigger"}' "${CONSUS_SCHEDULING_ENDPOINT}/pipes/staatskanzelei-kanton-zuerich/triggers/immediateTrigger"
 curl -i -X PUT -H 'Content-Type: application/json' $CURL_CREDS --data '{"status": "enabled", "id": "immediateTrigger"}' "${CONSUS_SCHEDULING_ENDPOINT}/pipes/bafu/triggers/immediateTrigger"

--- a/opendata.swiss/metadata/scripts/harvest.sh
+++ b/opendata.swiss/metadata/scripts/harvest.sh
@@ -14,6 +14,8 @@ else
   CURL_CREDS=""
 fi
 
+curl -i -X PUT -H 'Content-Type: application/json' $CURL_CREDS --data '{"status": "enabled", "id": "immediateTrigger"}' "${CONSUS_SCHEDULING_ENDPOINT}/pipes/metrics/triggers/immediateTrigger"
+
 # We disable the trigger for Staatskanzlei Kanton Zürich as their endpoint seems to be broken
 # curl -i -X PUT -H 'Content-Type: application/json' $CURL_CREDS --data '{"status": "enabled", "id": "immediateTrigger"}' "${CONSUS_SCHEDULING_ENDPOINT}/pipes/staatskanzelei-kanton-zuerich/triggers/immediateTrigger"
 curl -i -X PUT -H 'Content-Type: application/json' $CURL_CREDS --data '{"status": "enabled", "id": "immediateTrigger"}' "${CONSUS_SCHEDULING_ENDPOINT}/pipes/bafu/triggers/immediateTrigger"


### PR DESCRIPTION
I added the Piveau metrics components to the stack.
In the current state, there are some issues during harvesting, so I wasn't able to try them as expected…

I also got some issues while trying to run the stack, as my laptop is "low on disk" in terms of percentage.

I did the following:
- GraphDB: added some config to ignore the check, as else it was throwing errors
- ElasticSearch: added `./scripts/disable_es_disk_check.sh` script to quickly configure the instance to disable the checks

This might be useful for anyone who wants to run the stack locally and would face the same issues; this is why I'm also documenting this case.

Those changes are not intended to be done on the deployed instances, just for local ones.