### PR TITLE
[2026-04-14] Upgrade some GitHub Actions

### DIFF
--- a/.github/workflows/docker-ods-consus-importing-csw.yaml
+++ b/.github/workflows/docker-ods-consus-importing-csw.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-ods-consus-importing-csw.yaml
+++ b/.github/workflows/docker-ods-consus-importing-csw.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-ods-consus-importing-csw.yaml
+++ b/.github/workflows/docker-ods-consus-importing-csw.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push Docker images
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./opendata.swiss/piveau_modules/piveau-consus-importing-csw
           file: ./opendata.swiss/piveau_modules/piveau-consus-importing-csw/Dockerfile

--- a/.github/workflows/docker-ods-consus-importing-csw.yaml
+++ b/.github/workflows/docker-ods-consus-importing-csw.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-ods-consus-importing-csw.yaml
+++ b/.github/workflows/docker-ods-consus-importing-csw.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-ods-consus-importing-csw.yaml
+++ b/.github/workflows/docker-ods-consus-importing-csw.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/opendata-swiss/ods-consus-importing-csw

--- a/.github/workflows/docker-ods-consus-patching.yaml
+++ b/.github/workflows/docker-ods-consus-patching.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-ods-consus-patching.yaml
+++ b/.github/workflows/docker-ods-consus-patching.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-ods-consus-patching.yaml
+++ b/.github/workflows/docker-ods-consus-patching.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/opendata-swiss/ods-consus-patching

--- a/.github/workflows/docker-ods-consus-patching.yaml
+++ b/.github/workflows/docker-ods-consus-patching.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-ods-consus-patching.yaml
+++ b/.github/workflows/docker-ods-consus-patching.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push Docker images
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./opendata.swiss/piveau_modules/piveau-consus-patching
           file: ./opendata.swiss/piveau_modules/piveau-consus-patching/Dockerfile

--- a/.github/workflows/docker-ods-consus-patching.yaml
+++ b/.github/workflows/docker-ods-consus-patching.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker-ods-ui.yaml
+++ b/.github/workflows/docker-ods-ui.yaml
@@ -24,7 +24,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-ods-ui.yaml
+++ b/.github/workflows/docker-ods-ui.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-ods-ui.yaml
+++ b/.github/workflows/docker-ods-ui.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Build and push Docker images
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./opendata.swiss/ui
           file: ./opendata.swiss/ui/Dockerfile

--- a/.github/workflows/docker-ods-ui.yaml
+++ b/.github/workflows/docker-ods-ui.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-ods-ui.yaml
+++ b/.github/workflows/docker-ods-ui.yaml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/opendata-swiss/ods-ui

--- a/.github/workflows/docker-ods-ui.yaml
+++ b/.github/workflows/docker-ods-ui.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/preview-trigger.yaml
+++ b/.github/workflows/preview-trigger.yaml
@@ -64,7 +64,7 @@ jobs:
           version: v1.35.0
 
       - name: Set up Kustomize
-        uses: imranismail/setup-kustomize@v2
+        uses: imranismail/setup-kustomize@v3
 
       - name: Configure cluster context
         run: |

--- a/.github/workflows/preview-trigger.yaml
+++ b/.github/workflows/preview-trigger.yaml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
         with:
           version: v1.35.0
 


### PR DESCRIPTION
This PR upgrades the following GitHub Actions:

- `docker/build-push-action` to v7
- `docker/metadata-action` to v6
- `docker/login-action` to v4
- `docker/setup-buildx-action` to v4
- `docker/setup-qemu-action` to v4
- `sigstore/cosign-installer` to v4.1.1
- `imranismail/setup-kustomize` to v3
- `azure/setup-kubectl` to v5