### PR TITLE
Refactor dataset license handling and add OdsLicense utility functions

### DIFF
--- a/opendata.swiss/ui/app/components/dataset-detail/OdsDetailTermsOfUse.vue
+++ b/opendata.swiss/ui/app/components/dataset-detail/OdsDetailTermsOfUse.vue
@@ -9,7 +9,6 @@
       :title="t(`message.terms_of_use.ods_${termsName}.title`)"
       class="ods-terms-of-use_image">
   </div>
-
   <ul>
     <li>{{ t(`message.terms_of_use.ods_${termsName}.condition_1`) }}</li>
     <li>{{ t(`message.terms_of_use.ods_${termsName}.condition_2`) }}</li>
@@ -20,18 +19,19 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import { useI18n } from '#imports'
+import type { OdsLicense } from '~/piveau/get-ods-licenses'
 
 const { t } = useI18n()
 
 interface Props {
-  name: string
+  license: OdsLicense
 }
 
 const props = defineProps<Props>()
 
 const termsName = computed(() => {
-  const name = props.name
-  switch (name) {
+  const licnsesId = props.license.id
+  switch (licnsesId) {
     case 'http://dcat-ap.ch/vocabulary/licenses/terms_by':
       return 'by'
     case 'http://dcat-ap.ch/vocabulary/licenses/terms_open':
@@ -41,7 +41,7 @@ const termsName = computed(() => {
     case 'http://dcat-ap.ch/vocabulary/licenses/terms_by_ask':
       return 'by_ask'
     default:
-      return props.name
+      return props.license.id
   }
 })
 

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -146,8 +146,8 @@ export class DcatApChV2DatasetAdapter {
    * has a getLicenses property that aggregates the licenses of its distributions.
    *
    */
-  get licenses(): string[] {
-    return this.#dataset.getLicenses ?? []
+  get licenses() {
+    return this.#dataset.getOdsLicenses ?? []
   }
 
   /**

--- a/opendata.swiss/ui/app/model/dataset.ts
+++ b/opendata.swiss/ui/app/model/dataset.ts
@@ -3,10 +3,12 @@ import type { getKeywords } from '~/piveau/get-keywords'
 import type { getOdsAccrualPeriodicity } from '~/piveau/get-ods-accrual-periodicity'
 import type { getOdsCatalogInfo } from '~/piveau/get-ods-catalog-info'
 import type { getOdsFormats } from '~/piveau/get-ods-formats'
+import type { getOdsLicenses } from '~/piveau/get-ods-licenses'
 
 export type Dataset = ReturnType<ReturnType<typeof dcatApDataset>['setup']> & {
   getOdsFormats: ReturnType<typeof getOdsFormats>
   getKeywords: ReturnType<typeof getKeywords>
   getOdsCatalogInfo: ReturnType<typeof getOdsCatalogInfo>
   getOdsAccrualPeriodicity: ReturnType<typeof getOdsAccrualPeriodicity>
+  getOdsLicenses: ReturnType<typeof getOdsLicenses>
 }

--- a/opendata.swiss/ui/app/piveau/datasets.ts
+++ b/opendata.swiss/ui/app/piveau/datasets.ts
@@ -4,6 +4,7 @@ import { getKeywords } from './get-keywords'
 import { getOdsFormats } from './get-ods-formats'
 import { getOdsCatalogInfo } from './get-ods-catalog-info'
 import { getOdsAccrualPeriodicity } from './get-ods-accrual-periodicity'
+import { getOdsLicenses } from './get-ods-licenses'
 
 export const facets = ['catalog', 'categories', 'publisher', 'format', 'license', 'keywords']
 
@@ -29,6 +30,7 @@ export function useDatasetsSearch() {
       getOdsFormats: getOdsFormats(dataset),
       getOdsAccrualPeriodicity: getOdsAccrualPeriodicity(dataset),
       getResource: dataset.resource,
+      getOdsLicenses: getOdsLicenses(dataset),
     }
   })
 }

--- a/opendata.swiss/ui/app/piveau/get-ods-licenses.ts
+++ b/opendata.swiss/ui/app/piveau/get-ods-licenses.ts
@@ -1,0 +1,32 @@
+import type { Dataset } from '@piveau/sdk-core'
+
+/**
+ * Get Licenses for a dataset.
+ *
+ * @param dataset dataset
+ * @returns Array of unique licenses with id, label and resource
+ */
+export function getOdsLicenses(dataset: Dataset) {
+  const licenses = dataset.distributions?.flatMap(distribution => distribution.license ?? []) ?? []
+  const uniqueLicenses: Record<string, OdsLicense> = {}
+  licenses.forEach((license) => {
+    if (typeof license === 'string') {
+      uniqueLicenses[license] = { id: license, label: license, resource: license }
+    }
+    else if (license.id) {
+      uniqueLicenses[license.id] = {
+        id: license.id,
+        label: license.label ?? license.id,
+        resource: license.resource ?? license.id,
+      }
+    }
+  })
+  const licensesArray = Object.values(uniqueLicenses)
+  return licensesArray
+}
+
+export interface OdsLicense {
+  id: string
+  label: string
+  resource: string
+}

--- a/opendata.swiss/ui/pages/datasets/[datasetId]/index.vue
+++ b/opendata.swiss/ui/pages/datasets/[datasetId]/index.vue
@@ -133,14 +133,27 @@ await suspense()
             </h1>
             <MDC :value="dataset.description" />
             <!----><!---->
-            <aside v-if="dataset.publisher" class="authors">
-              <div class="disc-images" aria-hidden="true">
+            <aside
+              v-if="dataset.publisher"
+              class="authors"
+            >
+              <div
+                class="disc-images"
+                aria-hidden="true"
+              >
                 <div class="disc-image">
-                  <img src="https://picsum.photos/120/120/?image=29" :title="dataset.publisher.name">
+                  <img
+                    src="https://picsum.photos/120/120/?image=29"
+                    :title="dataset.publisher.name"
+                  >
                 </div>
               </div>
               <address class="authors__names">
-                <a class="link author__name link--external" target="_blank" :href="dataset.publisher.resource">{{ dataset.publisher.name }}</a>
+                <a
+                  class="link author__name link--external"
+                  target="_blank"
+                  :href="dataset.publisher.resource"
+                >{{ dataset.publisher.name }}</a>
               </address>
             </aside>
           </div>
@@ -155,7 +168,11 @@ await suspense()
                 <h2 class="h5">
                   {{ t(`message.header.navigation.terms_of_use`) }}
                 </h2>
-                <OdsDetailTermsOfUse v-for="value in dataset.licenses" :key="value" :name="value" />
+                <OdsDetailTermsOfUse
+                  v-for="value in dataset.licenses"
+                  :key="value.id"
+                  :license="value"
+                />
               </div>
             </div>
             <h2 class="h2">
@@ -191,12 +208,19 @@ await suspense()
             </div>
           </div>
           <div class="hidden container__aside md:block">
-            <div id="aside-content" class="sticky sticky--top">
+            <div
+              id="aside-content"
+              class="sticky sticky--top"
+            >
               <div class="box">
                 <h2 class="h5">
                   {{ t(`message.header.navigation.terms_of_use`) }}
                 </h2>
-                <OdsDetailTermsOfUse v-for="value in resultEnhanced?.getLicenses" :key="value" :name="value" />
+                <OdsDetailTermsOfUse
+                  v-for="value in dataset.licenses"
+                  :key="value.id"
+                  :license="value"
+                />
               </div>
               <div class="box">
                 <h2 class="h5">
@@ -211,7 +235,14 @@ await suspense()
 
       <section class="section publication-back-button-section">
         <div class="container">
-          <OdsButton title="Zurück" icon="ArrowLeft" variant="outline" class="btn--back" size="sm" @click="router.back()" />
+          <OdsButton
+            title="Zurück"
+            icon="ArrowLeft"
+            variant="outline"
+            class="btn--back"
+            size="sm"
+            @click="router.back()"
+          />
         </div>
       </section>
     </main>


### PR DESCRIPTION
Fixed the License image and messages on a dataset. It likely broke while adding a vocabulary.

The original getLicense getter returns an array of strings, which isn’t what I need. I need the IRI of the source, not a string.  

The getOdsLicense returns an array of OdsLicense objects with this interface
```ts
export interface OdsLicense {
  id: string
  label: string
  resource: string
}
```
