### PR TITLE
[CI] Fix undefined ref

### DIFF
--- a/.github/workflows/preview-trigger.yaml
+++ b/.github/workflows/preview-trigger.yaml
@@ -44,7 +44,6 @@ jobs:
       - name: Checkout branch
         uses: actions/checkout@v6
         with:
-          ref: ${{ steps.set_code_ref.outputs.code_ref }}
           fetch-depth: 0
 
       - name: Configure some variables

--- a/.github/workflows/preview-trigger.yaml
+++ b/.github/workflows/preview-trigger.yaml
@@ -41,11 +41,6 @@ jobs:
       repository-projects: write
 
     steps:
-      - name: Checkout branch
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
       - name: Configure some variables
         id: set_code_ref
         run: |
@@ -56,6 +51,12 @@ jobs:
             echo "code_ref=${{ github.ref_name }}" >> $GITHUB_OUTPUT
             echo "image_tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
+
+      - name: Checkout branch
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.set_code_ref.outputs.code_ref }}
+          fetch-depth: 0
 
       - name: Set up kubectl
         uses: azure/setup-kubectl@v5


### PR DESCRIPTION
This commit 583d7437f0d37a60366d593ac066d12b764a00bb changed the order of some steps.
But now the ref is pointing to an undefined value, as it is only defined on the next step.

I saw that the changes also made the `code_ref` part completely not used anymore.
This PR aims to restore that feature.