### PR TITLE
[CI] Upgrade some GitHub Actions for consus filter workflow

### DIFF
--- a/.github/workflows/docker-ods-consus-filter.yaml
+++ b/.github/workflows/docker-ods-consus-filter.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/docker-ods-consus-filter.yaml
+++ b/.github/workflows/docker-ods-consus-filter.yaml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Build and push Docker images
         id: docker_build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./opendata.swiss/piveau_modules/piveau-consus-filter
           file: ./opendata.swiss/piveau_modules/piveau-consus-filter/Dockerfile

--- a/.github/workflows/docker-ods-consus-filter.yaml
+++ b/.github/workflows/docker-ods-consus-filter.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-ods-consus-filter.yaml
+++ b/.github/workflows/docker-ods-consus-filter.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Docker meta
         id: docker_meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/opendata-swiss/ods-consus-filter

--- a/.github/workflows/docker-ods-consus-filter.yaml
+++ b/.github/workflows/docker-ods-consus-filter.yaml
@@ -25,7 +25,7 @@ jobs:
         uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/docker-ods-consus-filter.yaml
+++ b/.github/workflows/docker-ods-consus-filter.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v4.0.0
+        uses: sigstore/cosign-installer@v4.1.1
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
I just saw that the actions on the consus filter workflow are using older versions.
This PR upgrades the versions so that they are the same as the others.