### PR TITLE
Show multi value fields in detail table

### DIFF
--- a/opendata.swiss/ui/app/components/OdsInfoBlock.vue
+++ b/opendata.swiss/ui/app/components/OdsInfoBlock.vue
@@ -1,29 +1,14 @@
+<script setup lang="ts">
+const { title } = defineProps<{
+  title: string
+}>()
+</script>
+
 <template>
   <div
-    v-if="props.type == 'block'"
-    class="info-block odsTable border-t"
-  >
-    <h3 class="info-block__title">
-      {{ title }}
-    </h3>
-    <div>
-      <slot />
-    </div>
-  </div>
-  <div
-    v-if="props.type === 'row'"
-    class="odsTableRow"
-  >
-    <h3 class="info-block__title">
-      {{ title }}
-    </h3>
-    <div>
-      <slot />
-    </div>
-  </div>
-  <div
-    v-if="props.type === 'tree'"
-    class="info-block odsTable"
+    class="info-block border-t"
+    style="display: flex;
+    flex-direction: column;"
   >
     <h3 class="info-block__title">
       {{ title }}
@@ -33,31 +18,3 @@
     </div>
   </div>
 </template>
-
-<script setup lang="ts">
-interface OdsInfoBlockProps {
-  title: string
-  type: 'row' | 'block' | 'tree'
-}
-
-const props = defineProps<OdsInfoBlockProps>()
-</script>
-
-<style lang="scss">
-  .odsTable {
-    display: flex;
-    flex-direction: column;
-    margin-top: 0;
-  }
-  .odsTableRow {
-    display: grid;
-    grid-template-columns: 180px 1fr;
-    align-items: center;
-    column-gap: 1rem;
-    .info-block__title {
-      margin-bottom: 0;
-      font-weight: 600;
-      color: grey;
-    }
-  }
-</style>

--- a/opendata.swiss/ui/app/components/OdsInfoBlock.vue
+++ b/opendata.swiss/ui/app/components/OdsInfoBlock.vue
@@ -1,16 +1,63 @@
-<script setup lang="ts">
-const { title } = defineProps<{
-  title: string
-}>()
-</script>
-
 <template>
-  <div class="info-block border-t" style="display: flex; flex-direction: column;">
+  <div
+    v-if="props.type == 'block'"
+    class="info-block odsTable border-t"
+  >
     <h3 class="info-block__title">
       {{ title }}
     </h3>
     <div>
-      <slot/>
+      <slot />
+    </div>
+  </div>
+  <div
+    v-if="props.type === 'row'"
+    class="odsTableRow"
+  >
+    <h3 class="info-block__title">
+      {{ title }}
+    </h3>
+    <div>
+      <slot />
+    </div>
+  </div>
+  <div
+    v-if="props.type === 'tree'"
+    class="info-block odsTable"
+  >
+    <h3 class="info-block__title">
+      {{ title }}
+    </h3>
+    <div>
+      <slot />
     </div>
   </div>
 </template>
+
+<script setup lang="ts">
+interface OdsInfoBlockProps {
+  title: string
+  type: 'row' | 'block' | 'tree'
+}
+
+const props = defineProps<OdsInfoBlockProps>()
+</script>
+
+<style lang="scss">
+  .odsTable {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0;
+  }
+  .odsTableRow {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    align-items: center;
+    column-gap: 1rem;
+    .info-block__title {
+      margin-bottom: 0;
+      font-weight: 600;
+      color: grey;
+    }
+  }
+</style>

--- a/opendata.swiss/ui/app/components/dataset-detail/OdsDetailTableInfoBlock.vue
+++ b/opendata.swiss/ui/app/components/dataset-detail/OdsDetailTableInfoBlock.vue
@@ -1,0 +1,63 @@
+<template>
+  <div
+    v-if="props.type == 'block'"
+    class="info-block odsTable border-t"
+  >
+    <h3 class="info-block__title">
+      {{ title }}
+    </h3>
+    <div>
+      <slot />
+    </div>
+  </div>
+  <div
+    v-if="props.type === 'row'"
+    class="odsTableRow"
+  >
+    <h3 class="info-block__title">
+      {{ title }}
+    </h3>
+    <div>
+      <slot />
+    </div>
+  </div>
+  <div
+    v-if="props.type === 'tree'"
+    class="info-block odsTable"
+  >
+    <h3 class="info-block__title">
+      {{ title }}
+    </h3>
+    <div>
+      <slot />
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+interface OdsDetailTableInfoBlockProps {
+  title: string
+  type: 'row' | 'block' | 'tree'
+}
+
+const props = defineProps<OdsDetailTableInfoBlockProps>()
+</script>
+
+<style lang="scss">
+  .odsTable {
+    display: flex;
+    flex-direction: column;
+    margin-top: 0;
+  }
+  .odsTableRow {
+    display: grid;
+    grid-template-columns: 180px 1fr;
+    align-items: center;
+    column-gap: 1rem;
+    .info-block__title {
+      margin-bottom: 0;
+      font-weight: 600;
+      color: grey;
+    }
+  }
+</style>

--- a/opendata.swiss/ui/app/components/dataset-detail/OdsDetailsTable.vue
+++ b/opendata.swiss/ui/app/components/dataset-detail/OdsDetailsTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <OdsInfoBlock
+  <OdsDetailTableInfoBlock
     v-for="entry in props.tableEntries"
     :key="entry.label"
     :title="entry.label"
@@ -18,11 +18,11 @@
         :type="entry.blockType()"
       />
     </div>
-  </OdsInfoBlock>
+  </OdsDetailTableInfoBlock>
 </template>
 
 <script setup lang="ts">
-import OdsInfoBlock from '../OdsInfoBlock.vue'
+import OdsDetailTableInfoBlock from './OdsDetailTableInfoBlock.vue'
 import type { OdsTableEntry } from './model/table-entry'
 import OdsDetailsTableValue from './OdsDetailsTableValue.vue'
 

--- a/opendata.swiss/ui/app/components/dataset-detail/OdsDetailsTable.vue
+++ b/opendata.swiss/ui/app/components/dataset-detail/OdsDetailsTable.vue
@@ -1,73 +1,35 @@
 <template>
-  <div>
-    <template
-      v-for="entry in props.tableEntries"
-      :key="entry.label"
+  <OdsInfoBlock
+    v-for="entry in props.tableEntries"
+    :key="entry.label"
+    :title="entry.label"
+    :type="props.type"
+  >
+    <OdsDetailsTableValue
+      v-for="(data, index) in entry.value"
+      :key="index"
+      :value="data"
+    />
+    <div
+      v-if="entry.subFields.length > 0"
     >
-      <OdsInfoBlock :title="entry.label">
-        <template
-          v-for="(data, index) in entry.value"
-          :key="index"
-        >
-          <span v-if="data.type === 'value'">
-            <template v-if="data.value">
-              <template v-if="!isNaN(Date.parse(data.value))">
-                <OdsRelativeDateToggle :date="new Date(data.value)" />
-              </template>
-              <template v-else>
-                {{ data.value }}
-              </template>
-            </template>
-          </span>
-          <span v-if="data.type === 'href'">
-            <a
-              :href="data.href"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="link--external"
-            >{{ data.value }}</a>
-          </span>
-          <span
-            v-if="data.type === 'email'"
-            class="line"
-          >
-            <SvgIcon
-              icon="PaperPlane"
-              size="lg"
-            /><a :href="data.href">&lt;{{ data.value }}&gt;</a>
-          </span>
-          <span
-            v-if="data.type === 'telephone'"
-            class="line"
-          >
-            <SvgIcon
-              icon="Phone"
-              size="lg"
-            /><a :href="data.href">{{ data.value }}</a>
-          </span>
-        </template>
-      </OdsInfoBlock>
-    </template>
-  </div>
+      <OdsDetailsTable
+        :table-entries="entry.subFields"
+        :type="entry.blockType()"
+      />
+    </div>
+  </OdsInfoBlock>
 </template>
 
 <script setup lang="ts">
-import type { TableEntry } from './model/table-entry'
 import OdsInfoBlock from '../OdsInfoBlock.vue'
-import OdsRelativeDateToggle from '../OdsRelativeDateToggle.vue'
-import SvgIcon from '../SvgIcon.vue'
+import type { OdsTableEntry } from './model/table-entry'
+import OdsDetailsTableValue from './OdsDetailsTableValue.vue'
 
 interface OdsDetailsTableProps {
-  tableEntries: TableEntry[]
+  tableEntries: OdsTableEntry[]
+  type: 'row' | 'block' | 'tree'
 }
 
 const props = defineProps<OdsDetailsTableProps>()
 </script>
-
-<style lang="scss">
-  .line {
-    display: flex;
-    align-items: center;
-    flex-direction: row;
-  }
-</style>

--- a/opendata.swiss/ui/app/components/dataset-detail/OdsDetailsTableValue.vue
+++ b/opendata.swiss/ui/app/components/dataset-detail/OdsDetailsTableValue.vue
@@ -1,0 +1,45 @@
+<template>
+  <span v-if="value.nodeType === odsTableEntryType.String">{{ props.value.label }}&nbsp;</span>
+  <span v-if="value.nodeType === odsTableEntryType.Date"><OdsRelativeDateToggle :date="new Date(props.value.label)" /></span>
+  <span v-if="value.nodeType === odsTableEntryType.Href">
+    <a
+      :href="props.value.id"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="link--external"
+    >{{ props.value.label }}</a>
+  </span>
+  <span
+    v-if="value.nodeType === odsTableEntryType.Email"
+    class="line"
+  >
+    <a :href="`mailto:${props.value.label}`">&lt;{{ props.value.label }}&gt;</a>
+  </span>
+  <span
+    v-if="value.nodeType === odsTableEntryType.Telephone"
+    class="line"
+  ><a :href="`tel:${props.value.label}`">{{ props.value.label }}</a>
+  </span>
+</template>
+
+<script setup lang="ts">
+import { OdsTableEntryType, type OdsTableEntry } from './model/table-entry'
+import OdsRelativeDateToggle from '../OdsRelativeDateToggle.vue'
+
+interface OdsDetailsTableValueProps {
+  value: OdsTableEntry
+}
+
+const props = defineProps<OdsDetailsTableValueProps>()
+
+// Make enum available in template
+const odsTableEntryType = OdsTableEntryType
+</script>
+
+<style lang="scss">
+  .line {
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+  }
+</style>

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -1,7 +1,7 @@
 import type { LinkedDataFormats } from '@piveau/sdk-vue'
 import type { Dataset } from '../../../model/dataset'
 import { DcatApChV2DistributionAdapter } from './dcat-ap-ch-v2-distribution-adapter'
-import type { TableEntry } from './table-entry'
+import { OdsTableEntry, OdsTableEntryType } from './table-entry'
 import type { Catalog } from '~/piveau/get-ods-catalog-info'
 import type { TagItem } from '../../OdsTagItem.vue'
 import type { AppLanguage } from '~/constants/langages'
@@ -267,6 +267,7 @@ export class DcatApChV2DatasetAdapter {
 
   get propertyTable() {
     const rootNode = this.#dataset.getPropertyTable
+
     if (!rootNode) {
       return []
     }
@@ -274,74 +275,17 @@ export class DcatApChV2DatasetAdapter {
     const ignoredNode = ['catalogRecord']
     const nodesToConsider = rootNode.filter(n => n.data).filter(n => !ignoredNode.includes(n.id))
 
-    const table: TableEntry[] = []
+    const newTableEntries: OdsTableEntry[] = []
+
     for (const node of nodesToConsider) {
-      const entry = {} as Partial<TableEntry>
-
-      if (node.type === 'node' && node.data) {
-        entry.label = node.label
-        entry.nodeType = 'node'
-
-        if (node.data && node.data.length > 0) {
-          for (const child of node.data) {
-            if (child.type === 'value') {
-              if (!entry.value) {
-                entry.value = [{ value: child.data as string, type: 'value' }]
-              }
-              else {
-                entry.value.push({ value: child.data as string, type: 'value' })
-              }
-            }
-            else if (child.type === 'href') {
-              const hrefData = child.data as { label: string, href: string }
-              if (!entry.value) {
-                entry.value = [{ value: hrefData.label, href: hrefData.href, type: 'href' }]
-              }
-              else {
-                entry.value.push({ value: hrefData.label, href: hrefData.href, type: 'href' })
-              }
-            }
-            else {
-              if (node.id === 'publisher') {
-                // special handling for publisher node
-                for (const data of child.data ?? []) {
-                  if (!entry.value) {
-                    entry.value = [{ value: data.data as string, type: 'value' }]
-                  }
-                  else {
-                    entry.value.push({ value: data.data as string, type: 'value' })
-                  }
-                }
-              }
-              else if (node.id === 'contactPoint') {
-                // special handling for contactPoint node
-                const nameNode = child.data?.find(d => d.id === 'contactPointName')
-                const emailNode = child.data?.find(d => d.id === 'contactPointEmail')
-                const telephoneNode = child.data?.find(d => d.id === 'contactPointTelephone')
-                if (nameNode && emailNode && nameNode.data && emailNode.data) {
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  const emailAddress = ((emailNode.data as Array<any>)[0] as any).data
-
-                  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                  const nameData = ((nameNode.data as Array<any>)[0] as any).data
-                  const publisherName = nameData as string
-                  if (!entry.value) {
-                    entry.value = [{ value: publisherName, type: 'value' }]
-                    entry.value.push({ value: emailAddress, href: `mailto:${emailAddress}`, type: 'email' })
-                    if (telephoneNode && telephoneNode.data) {
-                      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                      const telephoneNumber = ((telephoneNode.data as Array<any>)[0] as any).data as string
-                      entry.value.push({ value: telephoneNumber, href: `tel:${telephoneNumber}`, type: 'telephone' })
-                    }
-                  }
-                }
-              }
-            }
-          }
-          table.push(entry as TableEntry)
-        }
+      if (!(node.type === 'node') || !node.data) {
+        continue
       }
+
+      const newTableEntry = new OdsTableEntry(node.label, node.id, OdsTableEntryType.Node)
+      newTableEntries.push(newTableEntry)
+      newTableEntry.addPiveauPropertyTableEntry(node.data || [])
     }
-    return table.sort((a, b) => a.label.localeCompare(b.label))
+    return newTableEntries.sort((a, b) => a.label.localeCompare(b.label))
   }
 }

--- a/opendata.swiss/ui/app/components/dataset-detail/model/table-entry.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/table-entry.ts
@@ -1,11 +1,125 @@
-export interface TableEntry {
+import type { PropertyTableEntry, PropertyTableEntryNode } from '@piveau/sdk-vue'
+
+/**
+ * This class represents an entry in the property table of a dataset. It can be a value or a node. A node can have subfields and values.
+ * The value of an entry can be a string, a date, an email, a telephone number or a href.
+ */
+export class OdsTableEntry {
   label: string
-  value: [
-    {
-      value: string
-      href?: string
-      type: 'value' | 'href' | 'email' | 'telephone'
-    },
-  ]
-  nodeType: 'node' | 'value' | 'href'
+  id: string
+  subFields: OdsTableEntry[] = []
+  nodeType: OdsTableEntryType
+  value: OdsTableEntry[] = []
+
+  /**
+   * Create a new table entry.
+   * @param label The label of the entry.
+   * @param id The id of the entry. This is used for nodes to identify them, but can be empty for value entries.
+   * @param nodeType The type of the entry. This is used to determine how to display the entry in the UI.
+   */
+  constructor(label: string, id: string, nodeType: OdsTableEntryType) {
+    this.label = label
+    this.id = id
+    this.nodeType = nodeType
+  }
+
+  /**
+   * Add entries from piveau to the table entry. This method is recursive for nodes.
+   * It also cleans up duplicates for email and date values.
+   * @param entries The entries from piveau to add to the table entry.
+   */
+  addPiveauPropertyTableEntry(entries: (PropertyTableEntry | PropertyTableEntryNode)[]): void {
+    for (const entry of entries) {
+      if (entry.type === 'node') {
+        const node = entry as PropertyTableEntryNode
+        const newTableEntry = new OdsTableEntry(node.label, node.id, OdsTableEntryType.Node)
+        newTableEntry.addPiveauPropertyTableEntry(node.data || [])
+        this.#addSubField(newTableEntry)
+        continue
+      }
+      // this is a value entry
+      const valueEntry = entry as PropertyTableEntry
+      if (valueEntry.type === 'value') {
+        const isDate = !isNaN(Date.parse(valueEntry.data as string))
+        if (isDate) {
+          this.#addValue(new OdsTableEntry(valueEntry.data as string, '', OdsTableEntryType.Date))
+        }
+        const isEmail = typeof valueEntry.data === 'string' && /^\S+@\S+\.\S+$/.test(valueEntry.data)
+        if (isEmail) {
+          this.#addValue(new OdsTableEntry(valueEntry.data as string, `mailto:${valueEntry.data}`, OdsTableEntryType.Email))
+        }
+        const isPhone = typeof valueEntry.data === 'string' && /^\+?[0-9\s\-()]+$/.test(valueEntry.data)
+        if (isPhone) {
+          this.#addValue(new OdsTableEntry(valueEntry.data as string, `tel:${valueEntry.data}`, OdsTableEntryType.Telephone))
+        }
+        else {
+          this.#addValue(new OdsTableEntry(valueEntry.data as string, '', OdsTableEntryType.String))
+        }
+      }
+      else if (valueEntry.type === 'href') {
+        const hrefData = valueEntry.data as { label: string, href: string }
+        this.#addValue(new OdsTableEntry(hrefData.label, hrefData.href, OdsTableEntryType.Href))
+      }
+      else {
+        console.warn('--------------------------------------------------------------')
+        console.warn('Unknown entry type:', valueEntry.type, 'for entry:', valueEntry)
+        console.warn('--------------------------------------------------------------')
+      }
+    }
+    this.#cleanEmailDuplicates()
+    this.#cleanDateDuplicates()
+  }
+
+  #addValue(value: OdsTableEntry) {
+    this.value.push(value)
+  }
+
+  #addSubField(subField: OdsTableEntry) {
+    this.subFields.push(subField)
+  }
+
+  blockType(): 'block' | 'row' | 'tree' {
+    if (this.subFields.filter(f => f.value.length > 0).length > 0) {
+      return 'row'
+    }
+    if (this.subFields.filter(f => f.subFields.length > 0).length > 0) {
+      return 'tree'
+    }
+    return 'block'
+  }
+
+  /**
+   * This method removes string values that have the same label as email values, as they are duplicates. It is called after adding all entries to the table entry.
+   */
+  #cleanEmailDuplicates() {
+    const emailValues = this.value.filter(v => v.nodeType === OdsTableEntryType.Email)
+    for (const emailValue of emailValues) {
+      // remove string values with the same label as the email value
+      this.value = this.value.filter(v => !(v.nodeType === OdsTableEntryType.String && v.label === emailValue.label))
+    }
+    this.subFields.forEach(subField => subField.#cleanEmailDuplicates())
+  }
+
+  /**
+   * This method removes string values that have the same label as date values, as they are duplicates. It is called after adding all entries to the table entry.
+   */
+  #cleanDateDuplicates() {
+    const dateValues = this.value.filter(v => v.nodeType === OdsTableEntryType.Date)
+    for (const dateValue of dateValues) {
+      // remove string values with the same label as the date value
+      this.value = this.value.filter(v => !(v.nodeType === OdsTableEntryType.String && v.label === dateValue.label))
+    }
+    this.subFields.forEach(subField => subField.#cleanDateDuplicates())
+  }
+}
+/**
+ * This enum represents the type of an entry in the property table of a dataset. It can be a string, a date, an email, a telephone number, a href or a node.
+ */
+export enum OdsTableEntryType {
+  Date = 'date',
+  String = 'string',
+  Href = 'href',
+  Email = 'email',
+  Telephone = 'telephone',
+  Node = 'node',
 }

--- a/opendata.swiss/ui/pages/datasets/[datasetId]/index.vue
+++ b/opendata.swiss/ui/pages/datasets/[datasetId]/index.vue
@@ -166,7 +166,10 @@ await suspense()
             <h2 class="h2">
               {{ t('message.dataset_detail.additional_information') }}
             </h2>
-            <OdsDetailsTable :table-entries="dataset.propertyTable"/>
+            <OdsDetailsTable
+              :table-entries="dataset.propertyTable"
+              type="block"
+            />
             <div v-if="dataset.getCategoriesForLanguage(locale).length > 0">
               <h2 class="h2">
                 {{ t('message.dataset_detail.categories') }}


### PR DESCRIPTION
The dataset detail table is very dynamic. It can show 
- key value pairs e.g. "Created:" "12.10.1976"
- key with multiple values e.g. "Language:" "de it fr en" 
- key with a sub key value set. e.g.  (you can see it as a tree)
```
Contact Points
   Ufficio federale dell'ambiente UFAM
   ------------------------------------
   Name: Ufficio federale dell'ambiente UFAM 
   E-Mail: <hydrologie@bafu.admin.ch>
   Telephone: +41 58 462 93 11
```

This change introduces a new OdsTableEntry class. This class is used to build up the Detail Table Trees. It's used to control and harmonize the original data structure and adds cleaner typing. 

It introduces a new and more clearer DataTableValue renderer component. It renders string, email, href, and date values. 

It adds the ability to OdsInfoBlock to render rows, blocks, (sub) trees.  