### PR TITLE
feat: sorting showcases, extracted composable

### DIFF
--- a/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
+++ b/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
@@ -15,7 +15,7 @@ body:
         config:
           address: http://piveau-ui/api/showcases
           # use the address below to harvest from locally-running app
-          #address: http://host.docker.internal:3000/api/showcases
+          # address: http://host.docker.internal:3000/api/showcases
           # address: http://172.17.0.1:3000/api/showcases
 
           catalogue: showcases-ods

--- a/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
+++ b/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
@@ -13,9 +13,9 @@ body:
         processed: false
       body:
         config:
-          address: http://piveau-ui/api/showcases
+          #address: http://piveau-ui/api/showcases
           # use the address below to harvest from locally-running app
-          # address: http://host.docker.internal:3000/api/showcases
+          address: http://host.docker.internal:3000/api/showcases
           # address: http://172.17.0.1:3000/api/showcases
 
           catalogue: showcases-ods

--- a/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
+++ b/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
@@ -13,9 +13,9 @@ body:
         processed: false
       body:
         config:
-          #address: http://piveau-ui/api/showcases
+          address: http://piveau-ui/api/showcases
           # use the address below to harvest from locally-running app
-          address: http://host.docker.internal:3000/api/showcases
+          #address: http://host.docker.internal:3000/api/showcases
           # address: http://172.17.0.1:3000/api/showcases
 
           catalogue: showcases-ods

--- a/opendata.swiss/metadata/piveau_profile/showcase.hub.shapes.ttl
+++ b/opendata.swiss/metadata/piveau_profile/showcase.hub.shapes.ttl
@@ -49,6 +49,11 @@ ex:Showcase_Shape a sh:NodeShape ;
           pv:mappingClass "DateTime" ;
           pv:mappingName "modified"
       ], [
+          sh:maxCount 1 ;
+          sh:path dcterms:issued ;
+          pv:mappingClass "DateTime" ;
+          pv:mappingName "issued"
+      ], [
           sh:minCount 1 ;
           sh:maxCount 4 ;
           sh:uniqueLang true ;

--- a/opendata.swiss/metadata/piveau_profile/showcase.hub.shapes.ttl
+++ b/opendata.swiss/metadata/piveau_profile/showcase.hub.shapes.ttl
@@ -1,3 +1,4 @@
+PREFIX dcterms: <http://purl.org/dc/terms/>
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -42,6 +43,11 @@ ex:Showcase_Shape a sh:NodeShape ;
                           pv:mappingClass "DateTime" ;
                           pv:mappingName "modified"
                       ]
+      ], [
+          sh:maxCount 1 ;
+          sh:path dcterms:modified ;
+          pv:mappingClass "DateTime" ;
+          pv:mappingName "modified"
       ], [
           sh:minCount 1 ;
           sh:maxCount 4 ;

--- a/opendata.swiss/ui/app/composables/sort.ts
+++ b/opendata.swiss/ui/app/composables/sort.ts
@@ -1,0 +1,18 @@
+import { ref, watch } from 'vue'
+import { type LocationQueryValue, useRoute, useRouter } from 'vue-router'
+
+export function useSorting(initialSort: string, sortCallback: (sortString: LocationQueryValue | LocationQueryValue[] | undefined) => void) {
+  const router = useRouter()
+  const route = useRoute()
+
+  const selectedSort = ref<string>(typeof route.query.sort === 'string' ? route.query.sort.replace(/ /g, '+') : initialSort || '')
+
+  watch(selectedSort, (sortString) => {
+    // use the route to update the query parameters
+    router.push({ query: { ...route.query, sort: sortString } })
+  })
+
+  watch(() => route.query.sort, sortCallback)
+
+  return { selectedSort }
+}

--- a/opendata.swiss/ui/app/composables/sort.ts
+++ b/opendata.swiss/ui/app/composables/sort.ts
@@ -3,7 +3,7 @@ import { type LocationQueryValue, useRoute, useRouter } from 'vue-router'
 
 interface UseSorting {
   initialSort?: string
-  sortCallback: (sortString: LocationQueryValue | LocationQueryValue[] | undefined) => void
+  sortCallback: (sortString: LocationQueryValue | LocationQueryValue[]) => void
 }
 
 export function useSorting({ initialSort, sortCallback }: UseSorting) {
@@ -17,7 +17,7 @@ export function useSorting({ initialSort, sortCallback }: UseSorting) {
     router.push({ query: { ...route.query, sort: sortString } })
   })
 
-  watch(() => route.query.sort, sortCallback)
+  watch(() => route.query.sort, value => value && sortCallback(value))
 
   return { selectedSort }
 }

--- a/opendata.swiss/ui/app/composables/sort.ts
+++ b/opendata.swiss/ui/app/composables/sort.ts
@@ -1,7 +1,12 @@
 import { ref, watch } from 'vue'
 import { type LocationQueryValue, useRoute, useRouter } from 'vue-router'
 
-export function useSorting(initialSort: string, sortCallback: (sortString: LocationQueryValue | LocationQueryValue[] | undefined) => void) {
+interface UseSorting {
+  initialSort?: string
+  sortCallback: (sortString: LocationQueryValue | LocationQueryValue[] | undefined) => void
+}
+
+export function useSorting({ initialSort, sortCallback }: UseSorting) {
   const router = useRouter()
   const route = useRoute()
 

--- a/opendata.swiss/ui/entrypoint.sh
+++ b/opendata.swiss/ui/entrypoint.sh
@@ -6,9 +6,9 @@ set -e
 
 # Only clone if content directory does not exist
 if [ ! -d "content" ]; then
-  git clone --depth 1 "https://github.com/${GITHUB_OWNER}/${GITHUB_CMS_REPO}.git" --no-checkout content
+  git clone "https://github.com/${GITHUB_OWNER}/${GITHUB_CMS_REPO}.git" --no-checkout content
   cd content
-  git fetch --depth 1 origin "${GITHUB_REF}"
+  git fetch origin "${GITHUB_REF}"
   git checkout FETCH_HEAD
   cd ..
 fi

--- a/opendata.swiss/ui/i18n/locales/de.json
+++ b/opendata.swiss/ui/i18n/locales/de.json
@@ -90,8 +90,10 @@
                     "button_title": "Ihre Showcase einreichen"
                 },
                 "sort_by": {
-                    "newest": "Neueste zuerst",
-                    "oldest": "Älteste zuerst",
+                    "newest": "Zuletzt aktualisiert",
+                    "oldest": "Früheste Aktualisierung",
+                    "issued_desc": "Neueste Showcases",
+                    "issued_asc": "Älteste Showcases",
                     "title_asc": "A-Z",
                     "title_desc": "Z-A"
                 }

--- a/opendata.swiss/ui/i18n/locales/de.json
+++ b/opendata.swiss/ui/i18n/locales/de.json
@@ -83,11 +83,17 @@
             "open": "Website starten",
             "search": {
                 "dataset_references": "{count} Datensätze",
-                "prompt": "Nach Datensätzen suchen...",
+                "prompt": "Nach Showcases suchen...",
                 "submit_prompt": {
                     "title": "Ihr Showcase hier?",
                     "abstract": "Reichen Sie Ihr eigenes Showcase ein, um Ihr Projekt mit der Community zu teilen, Ihre Datensätze zu bewerben und andere zu inspirieren.",
                     "button_title": "Ihre Showcase einreichen"
+                },
+                "sort_by": {
+                    "newest": "Neueste zuerst",
+                    "oldest": "Älteste zuerst",
+                    "title_asc": "A-Z",
+                    "title_desc": "Z-A"
                 }
             },
             "submission_form": {

--- a/opendata.swiss/ui/i18n/locales/en.json
+++ b/opendata.swiss/ui/i18n/locales/en.json
@@ -83,7 +83,13 @@
             "open": "Open website",
             "search": {
                 "dataset_references": "{count} dataset(s)",
-                "placeholder": "Search showcases",
+                "prompt": "Search showcases",
+                "sort_by": {
+                    "newest": "Newest first",
+                    "oldest": "Oldest first",
+                    "title_asc": "A-Z",
+                    "title_desc": "Z-A"
+                },
                 "submit_prompt": {
                     "title": "Your showcase here?",
                     "abstract": "Submit your own showcase to share your project with the community, advertise your datasets and inspire others.",

--- a/opendata.swiss/ui/i18n/locales/en.json
+++ b/opendata.swiss/ui/i18n/locales/en.json
@@ -85,8 +85,10 @@
                 "dataset_references": "{count} dataset(s)",
                 "prompt": "Search showcases",
                 "sort_by": {
-                    "newest": "Newest first",
-                    "oldest": "Oldest first",
+                    "newest": "Recently updated",
+                    "oldest": "Oldest updated",
+                    "issued_desc": "Newest showcases",
+                    "issued_asc": "Oldest showcases",
                     "title_asc": "A-Z",
                     "title_desc": "Z-A"
                 },

--- a/opendata.swiss/ui/i18n/locales/fr.json
+++ b/opendata.swiss/ui/i18n/locales/fr.json
@@ -85,8 +85,10 @@
                 "dataset_references": "{count} jeux de données",
                 "prompt": "Rechercher des showcases",
                 "sort_by": {
-                    "newest": "Les plus récents d'abord",
-                    "oldest": "Les plus anciens d'abord",
+                    "newest": "Mises à jour récentes",
+                    "oldest": "Anciennes mises à jour",
+                    "issued_desc": "Nouveaux showcases",
+                    "issued_asc": "Anciens showcases",
                     "title_asc": "A-Z",
                     "title_desc": "Z-A"
                 },

--- a/opendata.swiss/ui/i18n/locales/fr.json
+++ b/opendata.swiss/ui/i18n/locales/fr.json
@@ -83,7 +83,13 @@
             "open": "Ouvrir le site web",
             "search": {
                 "dataset_references": "{count} jeux de données",
-                "placeholder": "Rechercher des showcases",
+                "prompt": "Rechercher des showcases",
+                "sort_by": {
+                    "newest": "Les plus récents d'abord",
+                    "oldest": "Les plus anciens d'abord",
+                    "title_asc": "A-Z",
+                    "title_desc": "Z-A"
+                },
                 "submit_prompt": {
                     "title": "Votre vitrine ici?",
                     "abstract": "Soumettez votre propre vitrine pour partager votre projet avec la communauté, promouvoir vos jeux de données et inspirer les autres.",

--- a/opendata.swiss/ui/i18n/locales/it.json
+++ b/opendata.swiss/ui/i18n/locales/it.json
@@ -83,7 +83,13 @@
             "open": "Apri sito web",
             "search": {
                 "dataset_references": "{count} set di dati",
-                "placeholder": "Cerca showcases",
+                "prompt": "Cerca showcases",
+                "sort_by": {
+                    "newest": "Dal più recente",
+                    "oldest": "Dal più vecchio",
+                    "title_asc": "A-Z",
+                    "title_desc": "Z-A"
+                },
                 "submit_prompt": {
                     "title": "Il tuo showcase qui?",
                     "abstract": "Invia il tuo showcase per condividere il tuo progetto con la community, promuovere i tuoi dataset e ispirare gli altri.",

--- a/opendata.swiss/ui/i18n/locales/it.json
+++ b/opendata.swiss/ui/i18n/locales/it.json
@@ -85,8 +85,10 @@
                 "dataset_references": "{count} set di dati",
                 "prompt": "Cerca showcases",
                 "sort_by": {
-                    "newest": "Dal più recente",
-                    "oldest": "Dal più vecchio",
+                    "newest": "Aggiornamenti recenti",
+                    "oldest": "Aggiornamenti passati",
+                    "issued_desc": "Nuovi showcase",
+                    "issued_asc": "Vecchi showcase",
                     "title_asc": "A-Z",
                     "title_desc": "Z-A"
                 },

--- a/opendata.swiss/ui/package.json
+++ b/opendata.swiss/ui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prepare": "if [ -d node_modules/husky ]; then cd ../.. && husky; fi",
     "decap": "rimraf public/admin && (cd ../..; PORT=8088 decap-server) & dotenv -- vite src/admin",
-    "predev": "shx test -d content || git clone --depth 1 git@github.com:opendata-swiss/opendata-swiss-cms-content-test.git content",
+    "predev": "shx test -d content || git clone git@github.com:opendata-swiss/opendata-swiss-cms-content-test.git content",
     "dev": "HOST=0.0.0.0 nuxt dev",
     "api-tuner": "npx api-tuner@0.5.2 --base-iri http://localhost:3000",
     "lint": "eslint --quiet",

--- a/opendata.swiss/ui/pages/datasets/index.vue
+++ b/opendata.swiss/ui/pages/datasets/index.vue
@@ -78,11 +78,13 @@ const sortOptions = computed(() => {
     { value: 'modified+asc', text: t('message.dataset_search.sort_by.date_modified_asc') },
   ]
 })
-const { selectedSort } = useSorting((sortTerm) => {
-  if (sortTerm) {
-    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
-    piveauQueryParams.sort = selectedSort.value
-  }
+const { selectedSort } = useSorting({
+  sortCallback(sortTerm) {
+    if (sortTerm) {
+      selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
+      piveauQueryParams.sort = selectedSort.value
+    }
+  },
 })
 
 const piveauQueryParams: SearchParamsBase = reactive({

--- a/opendata.swiss/ui/pages/datasets/index.vue
+++ b/opendata.swiss/ui/pages/datasets/index.vue
@@ -80,10 +80,8 @@ const sortOptions = computed(() => {
 })
 const { selectedSort } = useSorting({
   sortCallback(sortTerm) {
-    if (sortTerm) {
-      selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
-      piveauQueryParams.sort = selectedSort.value
-    }
+    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
+    piveauQueryParams.sort = selectedSort.value
   },
 })
 

--- a/opendata.swiss/ui/pages/datasets/index.vue
+++ b/opendata.swiss/ui/pages/datasets/index.vue
@@ -22,6 +22,7 @@ import { syncFacetsFromRoute, useFacetSync } from '../../app/composables/useFace
 
 import OdsSearchPanel from '../../app/components/OdsSearchPanel.vue'
 import OdsSearchResults from '../../app/components/OdsSearchResults.vue'
+import { useSorting } from '../../app/composables/sort'
 
 const { t, locale } = useI18n()
 
@@ -77,11 +78,11 @@ const sortOptions = computed(() => {
     { value: 'modified+asc', text: t('message.dataset_search.sort_by.date_modified_asc') },
   ]
 })
-const selectedSort = ref<string>(typeof route.query.sort === 'string' ? route.query.sort.replace(/ /g, '+') : '')
-
-watch(selectedSort, (sortString) => {
-  // use the route to update the query parameters
-  router.push({ query: { ...route.query, sort: sortString } })
+const { selectedSort } = useSorting((sortTerm) => {
+  if (sortTerm) {
+    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
+    piveauQueryParams.sort = selectedSort.value
+  }
 })
 
 const piveauQueryParams: SearchParamsBase = reactive({
@@ -229,13 +230,6 @@ watch(() => route.query.q, (searchTerm) => {
   piveauQueryParams.q = searchInput.value
 })
 
-watch(() => route.query.sort, (sortTerm) => {
-  if (sortTerm) {
-    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
-    piveauQueryParams.sort = selectedSort.value
-  }
-})
-
 onMounted(() => {
   syncFacetsFromRoute({
     facets,
@@ -279,7 +273,10 @@ await suspense()
 
       <OdsSearchResults :results-count="getSearchResultsCount">
         <template #header-right>
-          <OdsSortSelect v-model="selectedSort" :options="sortOptions" />
+          <OdsSortSelect
+            v-model="selectedSort"
+            :options="sortOptions"
+          />
           <div class="separator separator--vertical" />
           <OdsListCardToggle v-model="listType" />
         </template>
@@ -287,10 +284,14 @@ await suspense()
         <!-- <div v-if="isFetching" class="is-fetching">
               Fetching...
             </div> -->
-        <OdsDatasetList :items="datasets" :list-type="listType" :search-params="route.query" />
+        <OdsDatasetList
+          :items="datasets"
+          :list-type="listType"
+          :search-params="route.query"
+        />
         <div class="pagination pagination--right">
           <OdsPagination
-            :current-page="(Number(route.query.page  ?? 1))"
+            :current-page="(Number(route.query.page ?? 1))"
             :total-pages="getSearchResultsPagesCount"
             :page-label="t('message.ods-pagination.page')"
             :total-pages-label="t('message.ods-pagination.of') + getSearchResultsPagesCount"
@@ -298,7 +299,7 @@ await suspense()
               {
                 icon: 'ChevronLeft',
                 label: t('message.ods-pagination.previous'),
-                link: { name: route.name, query: { ...route.query, page: (Number(route.query.page  ?? 1) - 1) } /*, hash: '#search-results'*/ },
+                link: { name: route.name, query: { ...route.query, page: (Number(route.query.page ?? 1) - 1) } /*, hash: '#search-results'*/ },
               },
               {
                 icon: 'ChevronRight',
@@ -312,7 +313,10 @@ await suspense()
         </div>
 
         <div class="notification notification--info">
-          <SvgIcon icon="InfoCircle" role="notification" />
+          <SvgIcon
+            icon="InfoCircle"
+            role="notification"
+          />
           <div class="notification__content">
             <div class="text--bold">
               Haben Sie nicht gefunden wonach Sie suchen?
@@ -321,7 +325,10 @@ await suspense()
               Gerne geben wir Ihnen auch persönlich Auskunft. Bitte melden Sie sich
               via Kontaktformular bei uns.
             </div>
-            <a href="#" class="link">Kontaktformular</a>
+            <a
+              href="#"
+              class="link"
+            >Kontaktformular</a>
           </div>
         </div>
       </OdsSearchResults>

--- a/opendata.swiss/ui/pages/showcases/index.vue
+++ b/opendata.swiss/ui/pages/showcases/index.vue
@@ -174,11 +174,14 @@ onMounted(() => {
 const { suspense } = query
 await suspense()
 
-const { selectedSort } = useSorting(initialSort, (sortTerm) => {
-  if (sortTerm) {
-    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
-    piveauQueryParams.sort = selectedSort.value
-  }
+const { selectedSort } = useSorting({
+  initialSort,
+  sortCallback(sortTerm) {
+    if (sortTerm) {
+      selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
+      piveauQueryParams.sort = selectedSort.value
+    }
+  },
 })
 
 const sortOptions = computed(() => {

--- a/opendata.swiss/ui/pages/showcases/index.vue
+++ b/opendata.swiss/ui/pages/showcases/index.vue
@@ -188,6 +188,8 @@ const sortOptions = computed(() => {
     { value: `title.${locale.value}+dsc`, text: t('message.showcase.search.sort_by.title_desc') },
     { value: 'modified+desc', text: t('message.showcase.search.sort_by.newest') },
     { value: 'modified+asc', text: t('message.showcase.search.sort_by.oldest') },
+    { value: 'issued+desc', text: t('message.showcase.search.sort_by.issued_desc') },
+    { value: 'issued+asc', text: t('message.showcase.search.sort_by.issued_asc') },
   ]
 })
 </script>

--- a/opendata.swiss/ui/pages/showcases/index.vue
+++ b/opendata.swiss/ui/pages/showcases/index.vue
@@ -16,6 +16,8 @@ import type { SearchResultFacetGroupLocalized } from '@piveau/sdk-vue'
 import OdsSearchPanel from '../../app/components/OdsSearchPanel.vue'
 import OdsSearchResults from '../../app/components/OdsSearchResults.vue'
 import { syncFacetsFromRoute, useFacetSync } from '../../app/composables/useFacetSync'
+import OdsSortSelect from '../../app/components/dataset/OdsSortSelect.vue'
+import { useSorting } from '../../app/composables/sort'
 
 const { locale, t } = useI18n()
 
@@ -82,11 +84,12 @@ function scrollToResults() {
   }
 }
 
+const initialSort = 'modified+desc'
 const piveauQueryParams: SearchParamsBase = reactive({
   limit: 10,
   page: route.query.page ? Number(route.query.page) - 1 : 0,
   q: Array.isArray(route.query.q) ? route.query.q.join(' ') : route.query.q || '',
-  sort: 'relevance',
+  sort: initialSort,
 })
 
 const { useSearch } = useShowcaseSearch()
@@ -170,6 +173,23 @@ onMounted(() => {
 
 const { suspense } = query
 await suspense()
+
+const { selectedSort } = useSorting(initialSort, (sortTerm) => {
+  if (sortTerm) {
+    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
+    piveauQueryParams.sort = selectedSort.value
+  }
+})
+
+const sortOptions = computed(() => {
+  const currentLocale = locale.value
+  return [
+    { value: `title.${currentLocale}+asc`, text: t('message.dataset_search.sort_by.title_asc') },
+    { value: `title.${currentLocale}+dsc`, text: t('message.dataset_search.sort_by.title_desc') },
+    { value: 'modified+desc', text: t('message.dataset_search.sort_by.date_modified_desc') },
+    { value: 'modified+asc', text: t('message.dataset_search.sort_by.date_modified_asc') },
+  ]
+})
 </script>
 
 <template>
@@ -189,6 +209,12 @@ await suspense()
     />
     <!-- results -->
     <OdsSearchResults :results-count="getSearchResultsCount">
+      <template #header-right>
+        <OdsSortSelect
+          v-model="selectedSort"
+          :options="sortOptions"
+        />
+      </template>
       <div class="ods-card-list">
         <ul class="search-results-list">
           <li

--- a/opendata.swiss/ui/pages/showcases/index.vue
+++ b/opendata.swiss/ui/pages/showcases/index.vue
@@ -177,10 +177,8 @@ await suspense()
 const { selectedSort } = useSorting({
   initialSort,
   sortCallback(sortTerm) {
-    if (sortTerm) {
-      selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
-      piveauQueryParams.sort = selectedSort.value
-    }
+    selectedSort.value = Array.isArray(sortTerm) ? sortTerm.join(' ') : sortTerm
+    piveauQueryParams.sort = selectedSort.value
   },
 })
 

--- a/opendata.swiss/ui/pages/showcases/index.vue
+++ b/opendata.swiss/ui/pages/showcases/index.vue
@@ -182,12 +182,11 @@ const { selectedSort } = useSorting(initialSort, (sortTerm) => {
 })
 
 const sortOptions = computed(() => {
-  const currentLocale = locale.value
   return [
-    { value: `title.${currentLocale}+asc`, text: t('message.dataset_search.sort_by.title_asc') },
-    { value: `title.${currentLocale}+dsc`, text: t('message.dataset_search.sort_by.title_desc') },
-    { value: 'modified+desc', text: t('message.dataset_search.sort_by.date_modified_desc') },
-    { value: 'modified+asc', text: t('message.dataset_search.sort_by.date_modified_asc') },
+    { value: `title.${locale.value}+asc`, text: t('message.showcase.search.sort_by.title_asc') },
+    { value: `title.${locale.value}+dsc`, text: t('message.showcase.search.sort_by.title_desc') },
+    { value: 'modified+desc', text: t('message.showcase.search.sort_by.newest') },
+    { value: 'modified+asc', text: t('message.showcase.search.sort_by.oldest') },
   ]
 })
 </script>

--- a/opendata.swiss/ui/server/api/showcases.ts
+++ b/opendata.swiss/ui/server/api/showcases.ts
@@ -21,6 +21,7 @@ interface AggregateShowcase {
   'text': Record<string, string | undefined>
   'tag': string[]
   'modified': string | undefined
+  'issued': string | undefined
 }
 
 const ldContext = {
@@ -54,6 +55,7 @@ const ldContext = {
   image: schema.image.value,
   tag: dcat.keyword.value,
   modified: dcterms.modified.value,
+  issued: dcterms.issued.value,
   Dataset: dcat.Dataset.value,
   piveau: 'https://piveau.eu/ns/voc#',
 }
@@ -76,6 +78,7 @@ export default defineEventHandler(async (event) => {
     const id = `showcase/${stem}`
     let aggregate = arr.find(agg => agg.id === id)
     if (!aggregate) {
+      const { modified, issued } = getShowcaseDates(rootDir, stem)
       aggregate = {
         id,
         'identifier': stem,
@@ -88,7 +91,8 @@ export default defineEventHandler(async (event) => {
         'datasets': mapDatasets(showcase.datasets) || [],
         'text': {},
         'tag': showcase.tags || [],
-        'modified': getLastModified(rootDir, stem),
+        modified,
+        issued,
       }
       arr.push(aggregate)
     }
@@ -130,7 +134,7 @@ async function stripMarkdown(md: string | undefined) {
   return stripped.value.toString()
 }
 
-function getLastModified(rootDir: string, stem: string) {
+function getShowcaseDates(rootDir: string, stem: string) {
   try {
     const showcasesDir = join(rootDir, 'content/showcases')
     const files = [
@@ -140,13 +144,23 @@ function getLastModified(rootDir: string, stem: string) {
       `${stem}.it.md`,
     ].join(' ')
 
-    const command = `git log -n 1 --format=%aI -- ${files}`
+    // Get all commit dates for the showcase files, sorted from newest to oldest
+    // Note: Accurate dates require a repository clone with sufficient history (avoid --depth 1)
+    const command = `git log --format=%aI -- ${files}`
     const result = execSync(command, { cwd: showcasesDir, encoding: 'utf-8' })
 
-    return result.trim() || undefined
+    const dates = result.trim().split('\n').filter(Boolean)
+
+    return {
+      modified: dates[0],
+      issued: dates.at(-1),
+    }
   }
   catch (e) {
-    console.error(`Failed to get last modified date for ${stem}`, e)
-    return undefined
+    console.error(`Failed to get git dates for ${stem}`, e)
+    return {
+      modified: undefined,
+      issued: undefined,
+    }
   }
 }

--- a/opendata.swiss/ui/server/api/showcases.ts
+++ b/opendata.swiss/ui/server/api/showcases.ts
@@ -3,6 +3,8 @@ import strip from 'strip-markdown'
 import remarkFrontmatter from 'remark-frontmatter'
 import { dcat, dcterms, rdfs, schema } from '@tpluscode/rdf-ns-builders'
 import type { ShowcasesCollectionItem } from '@nuxt/content'
+import { execSync } from 'node:child_process'
+import { join } from 'node:path'
 
 const stemPattern = /showcases\/(?<stem>.*)\.(?<lang>\w\w)$/
 
@@ -18,6 +20,7 @@ interface AggregateShowcase {
   'datasets': Array<{ identifier: string, label: string }>
   'text': Record<string, string | undefined>
   'tag': string[]
+  'modified': string | undefined
 }
 
 const ldContext = {
@@ -50,11 +53,13 @@ const ldContext = {
   identifier: dcterms.identifier.value,
   image: schema.image.value,
   tag: dcat.keyword.value,
+  modified: dcterms.modified.value,
   Dataset: dcat.Dataset.value,
   piveau: 'https://piveau.eu/ns/voc#',
 }
 export default defineEventHandler(async (event) => {
-  const showcases: ShowcasesCollectionItem[] = await queryCollection(event, 'showcases')
+  const { public: { rootDir } } = useRuntimeConfig(event)
+  const showcases = await queryCollection(event, 'showcases')
     .select('title', 'categories', 'datasets', 'description', 'rawbody', 'stem', 'image', 'tags', 'type')
     .where('active', '=', true)
     .all()
@@ -63,6 +68,11 @@ export default defineEventHandler(async (event) => {
     const arr = await promise
 
     const { stem, lang } = showcase.stem.match(stemPattern)?.groups || {}
+    if (!stem || !lang) {
+      console.warn(`${showcase.stem} did not match stem pattern`)
+      return arr
+    }
+
     const id = `showcase/${stem}`
     let aggregate = arr.find(agg => agg.id === id)
     if (!aggregate) {
@@ -78,6 +88,7 @@ export default defineEventHandler(async (event) => {
         'datasets': mapDatasets(showcase.datasets) || [],
         'text': {},
         'tag': showcase.tags || [],
+        'modified': getLastModified(rootDir, stem),
       }
       arr.push(aggregate)
     }
@@ -117,4 +128,25 @@ async function stripMarkdown(md: string | undefined) {
     .use(remarkFrontmatter)
     .process(md)
   return stripped.value.toString()
+}
+
+function getLastModified(rootDir: string, stem: string) {
+  try {
+    const showcasesDir = join(rootDir, 'content/showcases')
+    const files = [
+      `${stem}.de.md`,
+      `${stem}.en.md`,
+      `${stem}.fr.md`,
+      `${stem}.it.md`,
+    ].join(' ')
+
+    const command = `git log -n 1 --format=%aI -- ${files}`
+    const result = execSync(command, { cwd: showcasesDir, encoding: 'utf-8' })
+
+    return result.trim() || undefined
+  }
+  catch (e) {
+    console.error(`Failed to get last modified date for ${stem}`, e)
+    return undefined
+  }
 }


### PR DESCRIPTION
I added `dc:modified` and `dc:issued` to the showcase export and map it to ES. The values are computed from actual git history for each showcase