### PR TITLE
By ensuring that router.replace({ query: rest }) only executes when t…

### DIFF
--- a/opendata.swiss/ui/pages/datasets/[datasetId]/index.vue
+++ b/opendata.swiss/ui/pages/datasets/[datasetId]/index.vue
@@ -95,17 +95,17 @@ watch(() => route.query.search,
   () => {
     if (import.meta.client) {
       const { search, ...rest } = route.query
-      router.replace({ query: rest })
-      if (search && typeof search === 'string') {
-        searchBreadcrumb.value = {
-          id: 'search',
-          title: t('message.dataset_search.search_results'),
-          route: {
-            path: '/datasets',
-            query: search
-              ? Object.fromEntries(new URLSearchParams(decodeURIComponent(search)))
-              : {},
-          },
+      if (search) {
+        router.replace({ query: rest })
+        if (typeof search === 'string') {
+          searchBreadcrumb.value = {
+            id: 'search',
+            title: t('message.dataset_search.search_results'),
+            route: {
+              path: '/datasets',
+              query: Object.fromEntries(new URLSearchParams(decodeURIComponent(search))),
+            },
+          }
         }
       }
     }


### PR DESCRIPTION
…here is actually a search string to process, returning from the Distribution page (where the URL does not contain a ?search=...) will completely bypass the router interruption and allow the transition to safely read its DOM nodes.