### PR TITLE
add default metrics pipe

### DIFF
--- a/opendata.swiss/metadata/piveau_pipes/metrics.json
+++ b/opendata.swiss/metadata/piveau_pipes/metrics.json
@@ -1,0 +1,69 @@
+{
+  "header": {
+    "id": "7dbcff70-6bd5-495a-b7a1-3c139f86533d",
+    "name": "metrics",
+    "title": "System Metrics",
+    "context": "opendataswiss",
+    "transport": "payload",
+    "version": "2.0.0"
+  },
+  "body": {
+    "segments": [
+      {
+        "header": {
+          "name": "piveau-metrics-validating-shacl",
+          "segmentNumber": 1,
+          "title": "Metrics SHACL validation",
+          "processed": false
+        },
+        "body": {
+          "config": {}
+        }
+      },
+      {
+        "header": {
+          "name": "piveau-metrics-annotator",
+          "segmentNumber": 2,
+          "title": "Metrics annotations",
+          "processed": false
+        },
+        "body": {
+          "config": {}
+        }
+      },
+      {
+        "header": {
+          "name": "piveau-metrics-accessibility",
+          "segmentNumber": 3,
+          "title": "Metrics accessibility",
+          "processed": false
+        },
+        "body": {
+          "config": {}
+        }
+      },
+      {
+        "header": {
+          "name": "piveau-metrics-score",
+          "segmentNumber": 4,
+          "title": "Metrics scoring",
+          "processed": false
+        },
+        "body": {
+          "config": {}
+        }
+      },     
+      {
+        "header": {
+          "name": "piveau-consus-exporting-hub",
+          "segmentNumber": 5,
+          "title": "Exporting hub",
+          "processed": false
+        },
+        "body": {
+          "config": {}
+        }
+      }
+    ]
+  }
+}


### PR DESCRIPTION
using the local stack, the metrics pipe is triggered automatically for each dataset harvested.
The only issue is that all the runs remain in status active, but apparently the metrics metadata is populated in the triplestore, and available in the repo API (appending `/metrics` to the dataset API URL, for example `http://localhost:8081/datasets/10040-kanton-basel-landschaft/metrics`).
To check the same in TEST and INT, we should merge this, so that the pipe named `metrics` is found (it should be enough since the infrastructure is already configured with `PIVEAU_HUB_VALIDATOR'{"enabled":true,"metricsPipeName":"metrics","history":false}' `
