### PR TITLE
Make metrics script configurable (endpoint and key)

### DIFF
--- a/.github/workflows/script-manual-trigger.yaml
+++ b/.github/workflows/script-manual-trigger.yaml
@@ -26,7 +26,7 @@ on:
           - "TRIGGERS"
           - "METRICS"
         default: "HARVEST"
-      
+
       arguments:
         description: "Additional arguments (optional)"
         required: false
@@ -58,12 +58,16 @@ jobs:
           echo "CONSUS_SCHEDULING_ENDPOINT=${CONSUS_SCHEDULING_ENDPOINT}" >> .env
           echo "CONSUS_SCHEDULING_USERNAME=${CONSUS_SCHEDULING_USERNAME}" >> .env
           echo "CONSUS_SCHEDULING_PASSWORD=${CONSUS_SCHEDULING_PASSWORD}" >> .env
+          echo "PIVEAU_METRICS_CACHE_ENDPOINT=${PIVEAU_METRICS_CACHE_ENDPOINT}" >> .env
+          echo "PIVEAU_METRICS_CACHE_API_KEY=${PIVEAU_METRICS_CACHE_API_KEY}" >> .env
         env:
           PIVEAU_HUB_API_KEY: ${{ secrets.PIVEAU_HUB_API_KEY_INT }}
           HUB_REPO_ENDPOINT: ${{ secrets.HUB_REPO_ENDPOINT_INT }}
           CONSUS_SCHEDULING_ENDPOINT: ${{ secrets.CONSUS_SCHEDULING_ENDPOINT_INT }}
           CONSUS_SCHEDULING_USERNAME: ${{ secrets.CONSUS_SCHEDULING_USERNAME_INT }}
           CONSUS_SCHEDULING_PASSWORD: ${{ secrets.CONSUS_SCHEDULING_PASSWORD_INT }}
+          PIVEAU_METRICS_CACHE_ENDPOINT: ${{ secrets.PIVEAU_METRICS_CACHE_ENDPOINT_INT }}
+          PIVEAU_METRICS_CACHE_API_KEY: ${{ secrets.PIVEAU_METRICS_CACHE_API_KEY_INT }}
 
       - name: Generate .env file (TEST)
         if: ${{ github.event.inputs.environment == 'TEST' }}
@@ -74,12 +78,16 @@ jobs:
           echo "CONSUS_SCHEDULING_ENDPOINT=${CONSUS_SCHEDULING_ENDPOINT}" >> .env
           echo "CONSUS_SCHEDULING_USERNAME=${CONSUS_SCHEDULING_USERNAME}" >> .env
           echo "CONSUS_SCHEDULING_PASSWORD=${CONSUS_SCHEDULING_PASSWORD}" >> .env
+          echo "PIVEAU_METRICS_CACHE_ENDPOINT=${PIVEAU_METRICS_CACHE_ENDPOINT}" >> .env
+          echo "PIVEAU_METRICS_CACHE_API_KEY=${PIVEAU_METRICS_CACHE_API_KEY}" >> .env
         env:
           PIVEAU_HUB_API_KEY: ${{ secrets.PIVEAU_HUB_API_KEY_TEST }}
           HUB_REPO_ENDPOINT: ${{ secrets.HUB_REPO_ENDPOINT_TEST }}
           CONSUS_SCHEDULING_ENDPOINT: ${{ secrets.CONSUS_SCHEDULING_ENDPOINT_TEST }}
           CONSUS_SCHEDULING_USERNAME: ${{ secrets.CONSUS_SCHEDULING_USERNAME_TEST }}
           CONSUS_SCHEDULING_PASSWORD: ${{ secrets.CONSUS_SCHEDULING_PASSWORD_TEST }}
+          PIVEAU_METRICS_CACHE_ENDPOINT: ${{ secrets.PIVEAU_METRICS_CACHE_ENDPOINT_TEST }}
+          PIVEAU_METRICS_CACHE_API_KEY: ${{ secrets.PIVEAU_METRICS_CACHE_API_KEY_TEST }}
 
       - name: Run the selected action
         working-directory: ./opendata.swiss/metadata

--- a/opendata.swiss/metadata/.env.example
+++ b/opendata.swiss/metadata/.env.example
@@ -37,3 +37,4 @@ VITE_AUTHENTICATION_KEYCLOAK_CLIENT_ID="piveau-hub-ui"
 # Only used in the scripts
 HUB_REPO_ENDPOINT="http://localhost:8081"
 CONSUS_SCHEDULING_ENDPOINT="http://localhost:8090"
+PIVEAU_METRICS_CACHE_ENDPOINT="http://localhost:8185"

--- a/opendata.swiss/metadata/scripts/metrics.sh
+++ b/opendata.swiss/metadata/scripts/metrics.sh
@@ -7,4 +7,4 @@ set +a
 
 set -eu
 
-curl -i -X POST -H "X-API-Key:${PIVEAU_METRICS_CACHE_API_KEY}" http://localhost:8185/admin/refresh/
+curl -i -X POST -H "X-API-Key:${PIVEAU_METRICS_CACHE_API_KEY}" "${PIVEAU_METRICS_CACHE_ENDPOINT}/admin/refresh/"


### PR DESCRIPTION
The endpoint was hardcoded in the script.
This PR ensure it get the expected value for the expected environment.