### PR TITLE
meta_harvester, fetch organizations from I14Y

### DIFF
--- a/.github/workflows/script-manual-trigger.yaml
+++ b/.github/workflows/script-manual-trigger.yaml
@@ -25,6 +25,8 @@ on:
           - "DELETE_VOCABULARIES"
           - "TRIGGERS"
           - "METRICS"
+          - "ORGANIZATIONS"
+          - "DELETE_ORGANIZATIONS"
         default: "HARVEST"
 
       arguments:
@@ -108,6 +110,10 @@ jobs:
             ./scripts/triggers.sh;
           elif [ "${{ github.event.inputs.action }}" == "METRICS" ]; then
             ./scripts/metrics.sh;
+          elif [ "${{ github.event.inputs.action }}" == "ORGANIZATIONS" ]; then
+            ./scripts/organizations.sh "${{ github.event.inputs.arguments }}";
+          elif [ "${{ github.event.inputs.action }}" == "DELETE_ORGANIZATIONS" ]; then
+            ./scripts/organizations_delete.sh "${{ github.event.inputs.arguments }}";
           else
             echo "Unknown action: ${{ github.event.inputs.action }}";
             exit 1;

--- a/opendata.swiss/metadata/README.md
+++ b/opendata.swiss/metadata/README.md
@@ -9,6 +9,7 @@
 - `piveau_profile/`: Piveau profile
 - `piveau_scripts/`: Piveau scripts
 - `piveau_vocabularies/`: Piveau vocabularies
+- `piveau_organizations/`: Organizations
 
 ### Other resources
 
@@ -67,6 +68,27 @@ In case you want to remove them, run:
 
 To install the default vocabularies, open the shell at [http://localhost:8085/shell.html](http://localhost:8085/shell.html) and run `installVocabularies`.
 This could take some minutes.
+
+
+#### Organizations
+
+To create the organizations, run:
+
+```sh
+./scripts/organizations.sh
+```
+
+To remove all organizations, run:
+
+```sh
+./scripts/organizations_delete.sh
+```
+
+To remove a single organizations (for example, `ch-bafu`), run:
+```sh
+./scripts/organizations_delete.sh ch-bafu
+```
+
 
 #### Catalogues and Harvesting
 

--- a/opendata.swiss/metadata/meta_harvester/README.md
+++ b/opendata.swiss/metadata/meta_harvester/README.md
@@ -58,4 +58,13 @@ python -m meta_harvester generate-all-pipes
 
 ---
 
+### `generate-all-organizations`
 
+Fetches all organizations from I14Y and generates the organization definition files (e.g., `ch-bafu.ttl`) in the `piveau_organizations/` directory. 
+
+**Usage:**
+```bash
+python -m meta_harvester generate-all-organizations
+```
+
+---

--- a/opendata.swiss/metadata/meta_harvester/meta_harvester/__main__.py
+++ b/opendata.swiss/metadata/meta_harvester/meta_harvester/__main__.py
@@ -9,14 +9,15 @@ from typing import Union
 import requests
 import yaml
 from rdflib import BNode, Graph, Literal, Namespace, URIRef
-from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, XSD
+from rdflib.namespace import DCAT, DCTERMS, FOAF, RDF, XSD, ORG, SKOS
 from requests.exceptions import HTTPError
 
-from .api_clients import CkanClient
+from .api_clients import CkanClient, I14YClient
 
 CATALOGUES_PATH = os.getenv("CATALOGUES_PATH", "../piveau_catalogues")
 PIPES_PATH = "../piveau_pipes"
 TRIGGERS_PATH = "../piveau_triggers"
+ORGANIZATIONS_PATH = "../piveau_organizations"
 
 logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -195,6 +196,74 @@ def generate_bulk_triggers(pipe_names: list) -> None:
         }, trigger_file, indent=2)
 
 
+def generate_organization_metadata(
+        slug: str,
+        identifier: str,
+        subAgentOf_slug: str,
+        classification_code: str,
+        names: dict,
+        prefLabels: dict,
+        descriptions: dict,
+        homepage: str,
+) -> None:
+    """
+    Generates an RDF metadata file for an organization in Turtle format.
+
+    Args:
+        slug (str):                The slug of the organization.
+        identifier (str):          The identifier of the organization.
+        subAgentOf_slug (str):     The slug of the parent organization, if any.
+        classification_code (str): The classification code of the organization.
+        names (dict):              A dictionary of names for the organization, with language codes as keys.
+        prefLabels (dict):         A dictionary of preferred labels for the organization, with language codes as keys.
+        descriptions (dict):       A dictionary of descriptions for the organization, with language codes as keys.
+        homepage (str):            The URL to the organization's homepage.
+
+    Returns:
+        None
+    """
+    ODSN_ORGA = Namespace("https://opendata.swiss/id/organization/")
+    LEGAL_FORM = Namespace("https://register.ld.admin.ch/i14y/concept/legalForm/")
+
+    g = Graph()
+
+    g.bind("dcterms", DCTERMS)
+    g.bind("foaf", FOAF)
+
+    orga_uri = ODSN_ORGA[slug]
+
+    # Organization
+    g.add((orga_uri, RDF.type, FOAF.Organization))
+    g.add((orga_uri, RDF.type, ORG.Organization))
+    g.add((orga_uri, DCTERMS.identifier, Literal(identifier)))
+
+    if subAgentOf_slug:
+        g.add((orga_uri, ORG.subOrganizationOf, ODSN_ORGA[subAgentOf_slug]))
+    
+    if classification_code:
+        g.add((orga_uri, ORG.classification, LEGAL_FORM[classification_code])) 
+
+    for lang, name in names.items():
+        if name:
+            g.add((orga_uri, FOAF.name, Literal(name, lang=lang)))
+
+    for lang, prefLabel in prefLabels.items():
+        if prefLabel:
+            g.add((orga_uri, SKOS.prefLabel, Literal(prefLabel, lang=lang)))
+
+    for lang, desc in descriptions.items():
+        if desc:
+            g.add((orga_uri, DCTERMS.description, Literal(desc, lang=lang)))
+
+    if homepage:
+        g.add((orga_uri, FOAF.homepage, URIRef(homepage)))
+        g.add((URIRef(homepage), RDF.type, FOAF.Document))
+
+    output_file = Path(ORGANIZATIONS_PATH) / f"{slug}.ttl"
+    g.serialize(destination=output_file, format="turtle")
+    logger.info(f"Successfully generated RDF triples and saved to '{output_file}'")
+
+
 # run this locally and push the generated files to repo
 def generate_pipe_and_catalogue_files(pipes: bool = True, catalogues: bool = True) -> None:
     """
@@ -290,7 +359,48 @@ def generate_pipe_and_catalogue_files(pipes: bool = True, catalogues: bool = Tru
         generate_bulk_triggers(pipe_names)
 
 
+# run this locally and push the generated files to repo
+def generate_organizations() -> None:
+    """
+    Fetches all organizations from I14Y and generates corresponding
+    organization metadata files.
+    """
+    i14y_client = I14YClient()
 
+    try:
+        organizations = i14y_client.get_organizations()
+        logging.info(f"Collected {len(organizations)} organization(s) from I14Y.")
+    except HTTPError as e:
+        logging.error(f"Failed to fetch organizations from I14Y: {e}")
+        return
+    
+    # dictionary to map from the id to the slug. used for populating the 'subAgentOf' fields
+    id_to_slug = {org["id"]: org["slug"] for org in organizations}
+    
+    for i, organization in enumerate(organizations):
+        slug = organization["slug"]
+
+        logging.info(f"({i+1}/{len(organizations)}) Processing organization '{slug}'...")
+
+        # expect only one parent organization. error if more than one.
+        parent_orgs = organization.get("subAgentOf", [])
+        if len(parent_orgs) > 1:
+            logging.error(f"Organization '{slug}' ({organization["identifier"]}) has more than one parent organization: {parent_orgs}. Skipping.")
+            continue
+        elif len(parent_orgs) == 1:
+            parent_org_id = parent_orgs[0].get("id")
+            subAgentOf_slug = id_to_slug.get(parent_org_id)
+
+        generate_organization_metadata(
+            slug=slug,
+            identifier=organization["identifier"],
+            subAgentOf_slug=subAgentOf_slug if len(parent_orgs) == 1 else "",
+            classification_code = (organization.get("classification") or {}).get("code", ""),
+            names=to_dict(organization.get("name" or {})),
+            prefLabels=to_dict(organization.get("prefLabel" or {})),
+            descriptions=to_dict(organization.get("description" or {})),
+            homepage=organization.get("homePage", "")
+        )
 
 def main()-> None:
 
@@ -311,6 +421,11 @@ def main()-> None:
         "generate-all-catalogues", help="Generate all catalogue definition files from CKAN."
     )
     parser_generate_pipes.set_defaults(func=generate_pipe_and_catalogue_files, pipes=False, catalogues=True)
+
+    parser_generate_organizations = subparsers.add_parser(
+        "generate-all-organizations", help="Generate all organization definition files from I14Y."
+    )
+    parser_generate_organizations.set_defaults(func=generate_organizations)
 
     args = parser.parse_args()
 

--- a/opendata.swiss/metadata/meta_harvester/meta_harvester/api_clients.py
+++ b/opendata.swiss/metadata/meta_harvester/meta_harvester/api_clients.py
@@ -174,3 +174,32 @@ class CkanClient:
 
         return result
 
+class I14YClient:
+
+    AGENT_LIST_URL = "https://input-backend.i14y.c.bfs.admin.ch/api/Agent"
+
+    def get_organizations(self) -> list[dict]:
+        """Get all organizations from input-backend.i14y.c.bfs.admin.ch
+
+        Returns
+            list[dict]: I14Y organizations
+        """
+
+        session = requests_retry_session()
+        request = {}
+        response = session.get(self.AGENT_LIST_URL, params=request)
+        response.raise_for_status()
+        organizations = response.json()
+
+        # identifiers look like this: "CH_ZAS", "CHE-229.707.417", ...
+        # we create a URL friendly slug for each identifier, e.g. "CH_ZAS" -> "ch-zas", "CHE-229.707.417" -> "che-229-707-417"
+        # TODO: this is temporary solution until I14Y provides a slug field in the API response
+        for org in organizations:
+            identifier = org.get("identifier")
+            if identifier:
+                slug = identifier.lower().replace("_", "-").replace(".", "-")
+                org["slug"] = slug
+            else:
+                logger.warning(f"Organization with missing 'identifier' field: {org}")
+
+        return organizations

--- a/opendata.swiss/metadata/piveau_organizations/ch-agroscope.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-agroscope.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-agroscope> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_AGROSCOPE" ;
+    skos:prefLabel "Agroscope"@de,
+        "Agroscope"@en,
+        "Agroscope"@fr,
+        "Agroscope"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:homepage <https://www.agroscope.admin.ch> ;
+    foaf:name "Agroscope"@de,
+        "Agroscope"@en,
+        "Agroscope"@fr,
+        "Agroscope"@it .
+
+<https://www.agroscope.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-aramis.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-aramis.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-aramis> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ARAMIS" ;
+    skos:prefLabel "ARAMIS"@de,
+        "ARAMIS"@en,
+        "ARAMIS"@fr,
+        "ARAMIS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.aramis.admin.ch> ;
+    foaf:name "ARAMIS"@de,
+        "ARAMIS"@en,
+        "ARAMIS"@fr,
+        "ARAMIS"@it .
+
+<https://www.aramis.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-are.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-are.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-are> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das ARE ist die Fachbehörde des Bundes für Fragen der räumlichen Entwicklung, für die Verkehrspolitik, die nachhaltige Entwicklung sowie die transnationale Zusammenarbeit in räumlichen Belangen."@de,
+        "The ARE is the federal government's centre of excellence for issues concerning spatial development, transport policy, sustainable development and international cooperation in spatial planning matters."@en,
+        "L'ARE est le centre de compétences de la Confédération pour les questions liées au développement territorial, à la politique des transports, au développement durable ainsi qu'à la coopération transnationale en matière de territoire."@fr,
+        "L'ARE è l'autorità federale responsabile per le questioni di sviluppo territoriale, politica dei trasporti, sviluppo sostenibile e collaborazione transnazionale in ambito territoriale."@it ;
+    dcterms:identifier "CH_ARE" ;
+    skos:prefLabel "ARE"@de,
+        "ARE"@en,
+        "ARE"@fr,
+        "ARE"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.are.admin.ch> ;
+    foaf:name "Bundesamt für Raumentwicklung (ARE)"@de,
+        "Federal Office for Spatial Development (ARE)"@en,
+        "Office fédéral du développement territorial (ARE)"@fr,
+        "Ufficio federale dello sviluppo territoriale (ARE)"@it .
+
+<https://www.are.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-armasuisse.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-armasuisse.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-armasuisse> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ARMASUISSE" ;
+    skos:prefLabel "armasuisse"@de,
+        "armasuisse"@en,
+        "armasuisse"@fr,
+        "armasuisse"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-vbs> ;
+    foaf:name "Bundesamt für Rüstung (armasuisse)"@de,
+        "Federal Office for Defence Procurement (armasuisse)"@en,
+        " Office fédéral de l'armement armasuisse (ar)"@fr,
+        " Ufficio federale dell'armamento armasuisse (ar)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-astra.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-astra.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-astra> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ASTRA" ;
+    skos:prefLabel "ASTRA"@de,
+        "FEDRO"@en,
+        "OFROU"@fr,
+        "USTRA"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-uvek> ;
+    foaf:name "Bundesamt für Strassen (ASTRA)"@de,
+        "Federal Roads Office (FEDRO)"@en,
+        "Office fédéral des routes (OFROU)"@fr,
+        "Ufficio federale delle strade (USTRA)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-babs.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-babs.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-babs> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BABS" ;
+    skos:prefLabel "BABS"@de,
+        "FOCP"@en,
+        "OFPP"@fr,
+        "UFPP"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-vbs> ;
+    foaf:homepage <https://www.babs.admin.ch> ;
+    foaf:name "Bundesamt für Bevölkerungsschutz (BABS)"@de,
+        "Federal Office for Civil Protection (FOCP)"@en,
+        "Office fédéral de la protection de la population (OFPP)"@fr,
+        "Ufficio federale della protezione della popolazione (UFPP)"@it .
+
+<https://www.babs.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bacs.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bacs.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bacs> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BACS" ;
+    skos:prefLabel "BACS"@de,
+        "NCSC"@en,
+        "OFCS"@fr,
+        "UFCS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-vbs> ;
+    foaf:homepage <https://www.ncsc.admin.ch/> ;
+    foaf:name "Bundesamt für Cybersicherheit (BACS)"@de,
+        "National Cyber Security Centre (NCSC)"@en,
+        "Office fédéral de la cybersécurité (OFCS)"@fr,
+        "Ufficio federale della cibersicurezza (UFCS)"@it .
+
+<https://www.ncsc.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bafu.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bafu.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bafu> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das BAFU ist für die nachhaltige Nutzung der natürlichen Ressourcen wie Luft, Boden, Wasser und Wald, für die Klimapolitik, den Schutz vor Naturgefahren und für den Erhalt der Biodiversität zuständig."@de,
+        "The FOEN is responsible for the sustainable use of natural resources such as air, water, soil, and forests, for the climate policy, the protection against natural hazards and for the preservation of biodiversity."@en,
+        "L’OFEV est chargé d’assurer l’exploitation durable des ressources naturelles telles que l'air, l’eau, le sol et la forêt, la politique climatique, la protection contre les dangers naturels et le maintien de la biodiversité."@fr,
+        "L'UFAM è responsabile dell'uso sostenibile delle risorse naturali quali aria, acqua, suolo e foreste, della politica climatica, della protezione dai pericoli naturali e della conservazione della biodiversità."@it ;
+    dcterms:identifier "CH_BAFU" ;
+    skos:prefLabel "BAFU"@de,
+        "FOEN"@en,
+        "OFEV"@fr,
+        "UFAM"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-uvek> ;
+    foaf:homepage <https://bafu.admin.ch> ;
+    foaf:name "Bundesamt für Umwelt (BAFU)"@de,
+        "Federal Office for the Environment (FOEN)"@en,
+        "Office fédéral de l'environnement (OFEV)"@fr,
+        "Ufficio federale dell'ambiente (UFAM)"@it .
+
+<https://bafu.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bag.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bag.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bag> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das BAG engagiert sich für die Gesundheit der Bevölkerung. Es ist für die nationale Gesundheitspolitik sowie die Kranken- und Unfallversicherung zuständig. Und es macht sich auch auf internationaler Ebene für Gesundheitsthemen stark."@de,
+        "The Federal Office of Public Health (FOPH) is dedicated to the health of the Swiss population. It’s responsible for national healthcare policy and for health and accident insurance; and it promotes healthcare issues and interests on the international stage."@en,
+        "L’OFSP s’engage pour la santé de la population. Responsable de la politique nationale en matière de santé publique ainsi que de l’assurance maladie et accidents, il œuvre également au niveau international en faveur des questions de santé."@fr,
+        "L’UFSP si impegna per la salute della popolazione. È competente per la politica nazionale della sanità nonché per l’assicurazione malattie e infortuni. Inoltre si prodiga anche a livello internazionale per temi riguardanti la salute."@it ;
+    dcterms:identifier "CH_BAG" ;
+    skos:prefLabel "BAG"@de,
+        "FOPH"@en,
+        "OFSP"@fr,
+        "UFSP"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.bag.admin.ch> ;
+    foaf:name "Bundesamt für Gesundheit "@de,
+        "Federal Office of Public Health (FOPH)"@en,
+        "Office fédéral de la santé publique (OFSP)"@fr,
+        "Ufficio federale della sanità pubblica (UFSP)"@it .
+
+<https://www.bag.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bak.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bak.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bak> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BAK" ;
+    skos:prefLabel "BAK"@de,
+        "FOC"@en,
+        "OFC"@fr,
+        "UFC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.bak.admin.ch/> ;
+    foaf:name "Bundesamt für Kultur (BAK)"@de,
+        "Federal Office of Culture (FOC)"@en,
+        "Office fédéral de la culture (OFC)"@fr,
+        "Ufficio federale della cultura (UFC)"@it .
+
+<https://www.bak.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bakom.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bakom.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bakom> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Als Kompetenzzentrum des Bundes für Medien und Telekommunikation sorgt das BAKOM für einen freien, sicheren und vielfältigen Zugang zur Kommunikation in der Schweiz. Auch ist es ein wichtiger Akteur im Bereich der Digitalisierung. Wir schaffen Rahmenbedingungen, die Innovation fördern, Grundrechte schützen und den digitalen Wandel verantwortungsvoll begleiten. Ausserdem setzen wir uns für eine unabhängige, vielfältige und qualitativ hochwertige Medienlandschaft in der Schweiz ein."@de,
+        "As the federal government’s competence center for media and telecommunications, OFCOM ensures free, secure and diverse access to communication in Switzerland. It also plays an important role in the field of digitalisation. We create framework conditions that promote innovation, protect fundamental rights and support the digital transformation in a responsible manner. We are also committed to an independent, diverse and high-quality media landscape in Switzerland."@en,
+        "En tant que centre de compétence de la Confédération pour les médias et les télécommunications, l'OFCOM veille à ce que chacun puisse accéder librement, en toute sécurité et de manière diversifiée à la communication en Suisse. Il joue également un rôle important dans le domaine de la numérisation. Nous créons des conditions cadres qui favorisent l'innovation, protègent les droits fondamentaux et accompagnent la transformation numérique de manière responsable. Nous nous engageons en outre en faveur d'un paysage médiatique indépendant, diversifié et de qualité en Suisse."@fr,
+        "In qualità di centro di competenza della Confederazione per i media e le telecomunicazioni, l'UFCOM garantisce un accesso libero, sicuro e diversificato alla comunicazione in Svizzera. È inoltre un attore importante nel campo della digitalizzazione. Creiamo le condizioni quadro che promuovono l'innovazione, tutelano i diritti fondamentali e accompagnano in modo responsabile la trasformazione digitale. Ci impegniamo affinché la Svizzera disponga di un panorama mediatico indipendente, vario e di alta qualità."@it ;
+    dcterms:identifier "CH_BAKOM" ;
+    skos:prefLabel "BAKOM"@de,
+        "OFCOM"@en,
+        "OFCOM"@fr,
+        "UFCOM"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.bakom.admin.ch> ;
+    foaf:name "Bundesamt für Kommunikation (BAKOM)"@de,
+        "Federal Office of Communications (OFCOM)"@en,
+        "Office fédéral de la communication (OFCOM)"@fr,
+        "Ufficio federale delle comunicazioni (UFCOM)"@it .
+
+<https://www.bakom.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bar.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bar.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bar> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BAR" ;
+    skos:prefLabel "BAR"@de,
+        "SFA"@en,
+        "AFS"@fr,
+        "AFS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.bar.admin.ch> ;
+    foaf:name "Schweizerisches Bundesarchiv (BAR)"@de,
+        "Swiss Federal Archives (SFA)"@en,
+        "Archives fédérales suisses (AFS)"@fr,
+        "Archivio federale svizzero (AFS)"@it .
+
+<https://www.bar.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-baspo.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-baspo.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-baspo> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BASPO" ;
+    skos:prefLabel "BASPO"@de,
+        "BASPO"@en,
+        "BASPO"@fr,
+        "BASPO"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-vbs> ;
+    foaf:name "Bundesamt für Sport (BASPO)"@de,
+        "Federal Office of Sport (BASPO)"@en,
+        "Office fédéral de Sport (BASPO)"@fr,
+        "Ufficio federale di Sport (BASPO)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bav.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bav.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bav> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BAV" ;
+    skos:prefLabel "BAV"@de,
+        "FOT"@en,
+        "OFT"@fr,
+        "UFT"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-uvek> ;
+    foaf:homepage <https://www.bav.admin.ch> ;
+    foaf:name "Bundesamt für Verkehr (BAV)"@de,
+        "Federal Office of Transport (FOT)"@en,
+        "Office fédéral des transports (OFT)"@fr,
+        "Ufficio federale dei trasporti (UFT)"@it .
+
+<https://www.bav.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bazg.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bazg.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bazg> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das Bundesamt für Zoll und Grenzsicherheit sorgt für umfassende Sicherheit an der Grenze – zum Wohl von Bevölkerung, Wirtschaft und Staat. Es ist national und international gut vernetzt. Zu seinen Kernaufgaben gehören das sachgerechte und rasche Abfertigen von Handelswaren, der zügige Ablauf des Reiseverkehrs, die Bereiche Sicherheitspolizei und Migration und es verfügt mit der Strafverfolgung über eine eigene Ermittlungsbehörde."@de,
+        "The Federal Customs and Border Security Office (FOCBS) ensures comprehensive border security for the population, the economy and the state and is well connected nationally and internationally. Its main tasks include the correct and speedy taxation of tradable goods, the rapid handling of tourist traffic as well as the areas of migration and security police. The FOCBS has its own prosecuting authority."@en,
+        "L'Office fédéral de la douane et de la sécurité des frontières (OFDF) assure la sécurité globale à la frontière au profit de la population, de l'économie et de l'État. Il collabore étroitement avec d'autres autorités nationales et internationales. Parmi ses tâches principales figurent le dédouanement adéquat et rapide des marchandises de commerce, la gestion fluide du trafic touristique ainsi que les domaines de la police de sécurité et des migrations. Avec le domaine de direction Poursuites pénales, il dispose de sa propre autorité d'enquête."@fr,
+        "L'Ufficio federale della dogana e della sicurezza dei confini (UDSC) garantisce la sicurezza globale al confine a favore di popolazione, economia e Stato ed è ben interconnesso a livello nazionale e internazionale. Tra i suoi compiti principali rientrano la corretta e celere imposizione delle merci commerciabili, la rapida gestione del traffico turistico nonché gli ambiti della migrazione e della polizia di sicurezza. Con il Perseguimento penale l'UDSC dispone di una propria autorità inquirente."@it ;
+    dcterms:identifier "CH_BAZG" ;
+    skos:prefLabel "BAZG"@de,
+        "FOCBS"@en,
+        "OFDF"@fr,
+        "UDSC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-efd> ;
+    foaf:homepage <https://www.bazg.admin.ch/> ;
+    foaf:name "Bundesamt für Zoll und Grenzsicherheit (BAZG)"@de,
+        "Federal Office for Customs and Border Security (FOCBS)"@en,
+        "Office fédéral de la douane et de la sécurité des frontières (OFDF)"@fr,
+        "Ufficio federale della dogana e della sicurezza dei confini (UDSC)"@it .
+
+<https://www.bazg.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bazl.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bazl.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bazl> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BAZL" ;
+    skos:prefLabel "BAZL"@de,
+        "FOCA"@en,
+        "OFAC"@fr,
+        "UFAC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-uvek> ;
+    foaf:name "Bundesamt für Zivilluftfahrt (BAZL)"@de,
+        "Federal Office of Civil Aviation (FOCA)"@en,
+        "Office fédéral de l'aviation civile (OFAC)"@fr,
+        "Ufficio federale dell'aviazione civile (UFAC)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bbl.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bbl.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bbl> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BBL" ;
+    skos:prefLabel "BBL"@de,
+        "BBL"@en,
+        "OFCL"@fr,
+        "UFCL"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-efd> ;
+    foaf:homepage <https://www.bbl.admin.ch> ;
+    foaf:name "Bundesamt für Bauten und Logistik (BBL)"@de,
+        "Federal Office of Construction and Logistics (BBL)"@en,
+        " Office fédéral des constructions et de la logistique (OFCL)"@fr,
+        "Ufficio federale delle costruzioni e della logistica (UFCL)"@it .
+
+<https://www.bbl.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bfe.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bfe.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bfe> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das Bundesamt für Energie (BFE) ist das Kompetenzzentrum für Fragen der Energieversorgung und der Energienutzung im Eidgenössischen Departement für Umwelt, Verkehr, Energie und Kommunikation (UVEK)."@de,
+        "The Swiss Federal Office of Energy (SFOE) is the country's competence centre for issues relating to energy supply and energy use at the Federal Department of the Environment, Transport, Energy and Communications (DETEC).  "@en,
+        "L'Office fédéral de l'énergie (OFEN) est le centre de compétences du Département fédéral de l'environnement, des transports, de l'énergie et de la communication (DETEC) pour les questions liées à l'approvisionnement en énergie et à son utilisation."@fr,
+        "L'Ufficio federale dell'energia (UFE) è il centro di competenza in materia di approvvigionamento e di impiego dell'energia in seno al Dipartimento federale dell'ambiente, dei trasporti, dell'energia e delle comunicazioni (DATEC)."@it ;
+    dcterms:identifier "CH_BFE" ;
+    skos:prefLabel "BFE"@de,
+        "SFOE"@en,
+        "OFEN"@fr,
+        "UFE"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-uvek> ;
+    foaf:homepage <https://www.bfe.admin.ch> ;
+    foaf:name "Bundesamt für Energie (BFE)"@de,
+        "Swiss Federal Office of Energy (SFOE)"@en,
+        "Office fédéral de l'énergie (OFEN)"@fr,
+        "Ufficio federale dell'energia (UFE)"@it .
+
+<https://www.bfe.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bfs-poku.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bfs-poku.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bfs-poku> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BFS_POKU" ;
+    skos:prefLabel "POKU (BFS)"@de,
+        "POKU (FSO)"@en,
+        "POKU (OFS)"@fr,
+        "POKU (UST)"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch1> ;
+    foaf:name "Sektion Politik, Kultur, Medien (POKU) des Bundesamts für Statistik (BFS)"@de,
+        "Politics, Culture and Media Section (POKU) at the Federal Statistical Office (FSO)"@en,
+        "Section Politique, culture, médias (POKU) de l'Office fédéral de la statistique (OFS)"@fr,
+        "Sezione Politica, cultura, media (POKU) presso l'Ufficio federale di statistica (UST)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bit-sap.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bit-sap.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bit-sap> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BIT_SAP" ;
+    skos:prefLabel "BIT (SAP)"@de,
+        "FOITT (SAP)"@en,
+        "OFIT (SAP)"@fr,
+        "UFIT (SAP)"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-bit> ;
+    foaf:name "Bundesamt für Informatik und Telekommunikation (BIT), SAP"@de,
+        "Federal Office of Information Technology, Systems and Telecommunication (FOITT), SAP"@en,
+        "Office fédéral de l'informatique et de la télécommunication (OFIT), SAP"@fr,
+        "Ufficio federale dell'informatica e della telecomunicazione (UFIT), SAP"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bit.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bit.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bit> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BIT" ;
+    skos:prefLabel "BIT"@de,
+        "FOITT"@en,
+        "OFIT"@fr,
+        "UFIT"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-efd> ;
+    foaf:name "Bundesamt für Informatik und Telekommunikation (BIT)"@de,
+        "Federal Office of Information Technology, Systems and Telecommunication (FOITT)"@en,
+        "Office fédéral de l'informatique et de la télécommunication (OFIT)"@fr,
+        "Ufficio federale dell'informatica e della telecomunicazione (UFIT)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bj.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bj.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bj> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BJ" ;
+    skos:prefLabel "BJ"@de,
+        "FOI"@en,
+        "OFJ"@fr,
+        "UFG"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-ejpd> ;
+    foaf:name "Bundesamt für Justiz (BJ)"@de,
+        "Federal Office of Justice (FOI)"@en,
+        "Office fédéral de la justice (OFJ)"@fr,
+        "Ufficio federale di giustizia (UFG)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bk-dti-ds.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bk-dti-ds.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bk-dti-ds> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BK_DTI_DS" ;
+    skos:prefLabel "DS"@de,
+        "DS"@en,
+        "SNS"@fr,
+        "SDS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:name "Digitale Standardleistungen (DS)"@de,
+        "Digitale Standardleistungen DS"@en,
+        "Services numériques standards (SNS)"@fr,
+        "Servizi digitali standard (SDS)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bk-dti.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bk-dti.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bk-dti> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BK_DTI" ;
+    skos:prefLabel "BK-DTI"@de,
+        "FCh-DTI"@en,
+        "ChF-TNI"@fr,
+        "CaF-TDT"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-bk> ;
+    foaf:homepage <https://www.bk.admin.ch/bk/de/home/digitale-transformation-ikt-lenkung/bereichdti.html> ;
+    foaf:name "Bereich digitale Transformation und IKT-Lenkung (DTI) der Bundeskanzlei (BK)"@de,
+        "Digital Transformation and ICT Steering Sector (DTI) of the Federal Chancellery (FCh)"@en,
+        "Secteur Transformation numérique et gouvernance de l'informatique (TNI) de la Chancellerie fédérale (ChF)"@fr,
+        "Settore Trasformazione digitale e governance delle TIC (TDT) della Cancelleria federale (CaF)"@it .
+
+<https://www.bk.admin.ch/bk/de/home/digitale-transformation-ikt-lenkung/bereichdti.html> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bk.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bk.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bk> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BK" ;
+    skos:prefLabel "BK"@de,
+        "CCh"@en,
+        "ChF"@fr,
+        "CaF"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:name "Schweizerische Bundeskanzlei (BK)"@de,
+        "Swiss Federal Chancellery (FCh)"@en,
+        "Chancellerie fédérale (ChF)"@fr,
+        "Cancelleria federale (CaF)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bkb.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bkb.ttl
@@ -1,0 +1,24 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bkb> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die BKB ist das Strategieorgan der Bundesverwaltung für die Bereiche Waren- und Dienstleistungsbeschaffung. Sie nimmt insbesondere folgende Aufgaben wahr: Weiterentwicklung des öffentlichen Beschaffungswesens des Bundes, Nachhaltigkeit, Politik, Aus- und Weiterbildung im öffentlichen Beschaffungswesen."@de,
+        "La CA constitue l'organe stratégique de l'administration fédérale pour l'acquisition de marchandises et de services. Elle remplit en particulier les tâches suivantes: Développement des marchés publics de la Confédération, Développement durable, Politique et formation et perfectionnement."@fr,
+        "La Conferenza degli acquisti della Confederazione (CA) è l’organo strategico dell’Amministrazione federale per i settori acquisto di beni e acquisto di prestazioni di servizi. Svolge in particolare i seguenti compiti: ulteriore sviluppo del settore degli appalti pubblici della Confederazione, sostenibilità, politica nonché formazione e formazione continua nel settore degli appalti pubblici."@it ;
+    dcterms:identifier "CH_BKB" ;
+    skos:prefLabel "BKB"@de,
+        "BKB"@en,
+        "CA"@fr,
+        "CA"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.bkb.admin.ch> ;
+    foaf:name "Beschaffungskonferenz des Bundes (BKB)"@de,
+        "Federal Procurement Conference (BKB)"@en,
+        "Conférence des achats de la Confédération (CA)"@fr,
+        "Conferenza degli acquisti della Confederazione (CA)"@it .
+
+<https://www.bkb.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-blv.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-blv.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-blv> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BLV" ;
+    skos:prefLabel "BLV"@de,
+        "FSVO"@en,
+        "OSAV"@fr,
+        "USAV"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.blv.admin.ch> ;
+    foaf:name "Bundesamt für Lebensmittelsicherheit und Veterinärwesen (BLV)"@de,
+        "Federal Food Safety and Veterinary Office (FSVO)"@en,
+        "Office fédéral de la sécurité alimentaire et des affaires vétérinaires (OSAV)"@fr,
+        "Ufficio federale della sicurezza alimentare e di veterinaria (USAV)"@it .
+
+<https://www.blv.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-blw.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-blw.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-blw> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BLW" ;
+    skos:prefLabel "BLW"@de,
+        "FOAG"@en,
+        "OFAG"@fr,
+        "UFAG"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:homepage <https://blw.admin.ch> ;
+    foaf:name "Bundesamt für Landwirtschaft (BLW)"@de,
+        "Federal Office for Agriculture (FOAG)"@en,
+        "Office fédéral de l'agriculture (OFAG)"@fr,
+        "Ufficio federale dell'agricoltura (UFAG)"@it .
+
+<https://blw.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bsv.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bsv.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bsv> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BSV" ;
+    skos:prefLabel "BSV"@de,
+        "FSIO"@en,
+        "OFAS"@fr,
+        "UFAS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.bsv.admin.ch/> ;
+    foaf:name "Bundesamt für Sozialversicherungen (BSV)"@de,
+        "Federal Social Insurance Office (FSIO)"@en,
+        "Office fédéral des assurances sociales (OFAS)"@fr,
+        "Ufficio federale delle assicurazioni sociali (UFAS)"@it .
+
+<https://www.bsv.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-bwl.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-bwl.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-bwl> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_BWL" ;
+    skos:prefLabel "BWL"@de,
+        "BWL"@en,
+        "BWL"@fr,
+        "BWL"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:name "Bundesamt für wirtschaftliche Landesversorgung (BWL)"@de,
+        "Federal Office of wirtschaftliche Landesversorgung (BWL)"@en,
+        "Office fédéral de wirtschaftliche Landesversorgung (BWL)"@fr,
+        "Ufficio federale di wirtschaftliche Landesversorgung (BWL)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-cnai.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-cnai.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-cnai> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_CNAI" ;
+    skos:prefLabel "CNAI"@de,
+        "CNAI"@en,
+        "CNAI"@fr,
+        "CNAI"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:name "Kompetenznetzwerk für künstliche Intelligenz (CNAI)"@de,
+        "Competence Network for Artificial Intelligence (CNAI)"@en,
+        "Réseau de compétences en intelligence artificielle (CNAI)"@fr,
+        "Rete di competenze per l’intelligenza artificiale (CNAI)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-deza.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-deza.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-deza> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_DEZA" ;
+    skos:prefLabel "DEZA"@de,
+        "SDC"@en,
+        "DDC"@fr,
+        "DSC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-eda> ;
+    foaf:homepage <https://www.deza.admin.ch> ;
+    foaf:name "Direktion für Entwicklung und Zusammenarbeit (DEZA)"@de,
+        "Swiss Agency for Development and Cooperation (SDC)"@en,
+        "Direction du développement et de la coopération (DDC)"@fr,
+        "Direzione dello sviluppo e della cooperazione (DSC)"@it .
+
+<https://www.deza.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-didas.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-didas.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-didas> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_DIDAS" ;
+    skos:prefLabel "DIDAS"@de,
+        "DIDAS"@en,
+        "DIDAS"@fr,
+        "DIDAS"@it ;
+    foaf:name "DIDAS"@de,
+        "DIDAS"@en,
+        "DIDAS"@fr,
+        "DIDAS"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-dvs.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-dvs.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-dvs> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_DVS" ;
+    skos:prefLabel "DVS"@de,
+        "DPS"@en,
+        "ANS"@fr,
+        "ADS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0224> ;
+    foaf:homepage <https://www.digitale-verwaltung-schweiz.ch> ;
+    foaf:name "Digitale Verwaltung Schweiz (DVS)"@de,
+        "Digital Public Services Switzerland (DPS)"@en,
+        "Administration numérique suisse (ANS)"@fr,
+        "Amministrazione digitale Svizzera (ADS)"@it .
+
+<https://www.digitale-verwaltung-schweiz.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-eda.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-eda.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-eda> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das EDA wahrt die aussenpolitischen Interessen der Schweiz. Es pflegt Beziehungen zu anderen Staaten und zu internationalen Organisationen wie der EU oder der UNO. Es bietet Dienstleistungen für Schweizerinnen und Schweizer im Ausland an. Auch die Entwicklungszusammenarbeit und die humanitäre Hilfe gehören zu seinen Aufgaben. Mit ihren rund 170 Vertretungen ist die Schweiz rund um den Globus präsent."@de,
+        "The FDFA safeguards Switzerland's foreign policy interests. It maintains relations with other states and international organisations such as the EU and UN, and provides services for Swiss citizens abroad. It is also responsible for Switzerland's development cooperation and humanitarian aid. Switzerland maintains a global presence through its approximately 170 representations."@en,
+        "Le DFAE sauvegarde les intérêts de la Suisse en matière de politique extérieure. Il entretient des relations avec d’autres États et des organisations internationales telles que l’UE et l’ONU. Il propose des prestations aux citoyennes et citoyens suisses à l’étranger. La coopération au développement et l’aide humanitaire entrent également dans son champ d’activités. La Suisse est présente dans le monde entier grâce à un réseau comptant quelque 170 représentations."@fr,
+        "Il DFAE tutela gli interessi della Svizzera in materia di politica estera. Cura le relazioni con altri Stati e con organizzazioni internazionali come l’UE e l’ONU. Offre servizi alle Svizzere e agli Svizzeri che vivono o si trovano all’estero. I suoi compiti comprendono anche la cooperazione allo sviluppo e l’aiuto umanitario. Grazie alle sue circa 170 rappresentanze, la Svizzera è presente in tutto il mondo."@it ;
+    dcterms:identifier "CH_EDA" ;
+    skos:prefLabel "EDA"@de,
+        "FDFA"@en,
+        "DFAE"@fr,
+        "DFAE"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.eda.admin.ch> ;
+    foaf:name "Eidgenössisches Departement für auswärtige Angelegenheiten (EDA)"@de,
+        "Federal Department of Foreign Affairs (FDFA)"@en,
+        "Département fédéral des affaires étrangères (DFAE)"@fr,
+        "Dipartimento federale degli affari esteri (DFAE)"@it .
+
+<https://www.eda.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-educa.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-educa.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-educa> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Als Fachagentur im Auftrag von Bund und Kantonen verbindet Educa die technologischen Entwicklungen mit der Qualitätsentwicklung im Bildungsraum Schweiz."@de,
+        "As a specialist agency commissioned by the Confederation and cantons, we combine technological developments with quality improvements in the Swiss education space."@en,
+        "En tant qu'agence spécialisée mandatée par la Confédération et les cantons, Educa associe les développements technologiques au développement de la qualité dans l’espace suisse de formation. "@fr,
+        "In qualità di agenzia specializzata, su mandato della Confederazione e dei Cantoni, Educa associa gli sviluppi tecnologici allo sviluppo della qualità nel settore della formazione in Svizzera."@it ;
+    dcterms:identifier "CH_EDUCA" ;
+    skos:prefLabel "EDUCA"@de,
+        "EDUCA"@en,
+        "EDUCA"@fr,
+        "EDUCA"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0224> ;
+    foaf:homepage <https://www.educa.ch> ;
+    foaf:name "Educa"@de,
+        "Educa"@en,
+        "Educa"@fr,
+        "Educa"@it .
+
+<https://www.educa.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-efk.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-efk.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-efk> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die Eidgenössische Finanzkontrolle EFK ist das Finanzaufsichtsorgan der Schweizerischen Eidgenossenschaft."@de,
+        "The Swiss Federal Audit Office (SFAO) is the financial supervisory body of the Swiss Confederation."@en,
+        "Le Contrôle fédéral des finances (CDF) est l'organe de surveillance financière de la Confédération suisse."@fr,
+        "Il Controllo federale delle finanze (CDF) è l'organo di vigilanza finanziaria della Confederazione svizzera."@it ;
+    dcterms:identifier "CH_EFK" ;
+    skos:prefLabel "EFK"@de,
+        "SFAO"@en,
+        "CDF"@fr,
+        "CDF"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-efd> ;
+    foaf:homepage <https://www.efk.admin.ch> ;
+    foaf:name "Eidgenössische Finanzkontrolle (EFK)"@de,
+        "Swiss Federal Audit Office (SFAO)"@en,
+        "Contrôle fédéral des finances (CDF)"@fr,
+        "Controllo federale delle finanze (CDF)"@it .
+
+<https://www.efk.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-efv.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-efv.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-efv> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_EFV" ;
+    skos:prefLabel "EFV"@de,
+        "FFA"@en,
+        "AFF"@fr,
+        "AFF"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-efd> ;
+    foaf:name "Eidgenössische Finanzverwaltung (EFV)"@de,
+        "Federal Finance Administration (FFA)"@en,
+        "Administration fédérale des finances (AFF)"@fr,
+        "Amministrazione federale delle finanze (AFF)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-ehealth.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-ehealth.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-ehealth> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_eHealth" ;
+    skos:prefLabel "eHealth Suisse"@de,
+        "eHealth Suisse"@en,
+        "eHealth Suisse"@fr,
+        "eHealth Suisse"@it ;
+    foaf:name "eHealth Suisse"@de,
+        "eHealth Suisse"@en,
+        "eHealth Suisse"@fr,
+        "eHealth Suisse"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-ehra.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-ehra.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-ehra> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_EHRA" ;
+    skos:prefLabel "EHRA"@de,
+        "EHRA"@en,
+        "OFRC"@fr,
+        "UFRC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.bj.admin.ch/bj/de/home/wirtschaft/handelsregister.html> ;
+    foaf:name "Eidgenössisches Amt für das Handelsregister (EHRA)"@de,
+        "Federal Commercial Registry Office (EHRA)"@en,
+        "Office fédéral du registre du commerce (OFRC)"@fr,
+        "Ufficio federale del registro di commercio (UFRC)"@it .
+
+<https://www.bj.admin.ch/bj/de/home/wirtschaft/handelsregister.html> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-elcom.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-elcom.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-elcom> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ELCOM" ;
+    skos:prefLabel "ElCom"@de,
+        "ElCom"@en,
+        "ElCom"@fr,
+        "ElCom"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.elcom.admin.ch/> ;
+    foaf:name "Eidgenössische Elektrizitätskommission (ElCom)"@de,
+        "Federal Electricity Commission (ElCom)"@en,
+        "Commission fédérale de l'électricité (ElCom)"@fr,
+        "Commissione federale dell'energia elettrica (ElCom)"@it .
+
+<https://www.elcom.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-eoperations.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-eoperations.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-eoperations> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_eOperations" ;
+    skos:prefLabel "eOperations Schweiz"@de,
+        "eOperations Switzerland"@en,
+        "eOperations Suisse"@fr,
+        "eOperations Svizzera"@it ;
+    foaf:name "eOperations Schweiz"@de,
+        "eOperations Switzerland"@en,
+        "eOperations Suisse"@fr,
+        "eOperations Svizzera"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-epa.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-epa.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-epa> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_EPA" ;
+    skos:prefLabel "EPA"@de,
+        "EPA"@en,
+        "OFPER"@fr,
+        "UFPER"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.epa.admin.ch> ;
+    foaf:name "Eidgenössisches Personalamt EPA"@de,
+        "Eidgenössisches Personalamt EPA"@en,
+        "Office fédéral du personnel OFPER"@fr,
+        "Ufficio federale del personale UFPER"@it .
+
+<https://www.epa.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-esa.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-esa.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-esa> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ESA" ;
+    skos:prefLabel "ESA"@de,
+        "ESA"@en,
+        "SFF"@fr,
+        "VFF"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.esa.admin.ch/> ;
+    foaf:name "Eidgenössische Stiftungsaufsicht ESA"@de,
+        "Eidgenössische Stiftungsaufsicht ESA"@en,
+        "Surveillance fédérale des fondations SFF"@fr,
+        "Vigilanza federale sulle fondazioni VFF"@it .
+
+<https://www.esa.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-esbk.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-esbk.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-esbk> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die ESBK beaufsichtigt die Schweizer Spielbanken, veranlagt die Spielbankenabgabe und bekämpft das illegale Geldspiel. Die ESBK ist unabhängig. Administrativ ist sie dem Eidgenössischen Justiz- und Polizeidepartement zugeordnet."@de,
+        "The Federal Gaming Board (FGB) is responsible for supervising Swiss casinos, levying casino tax and combating illegal gambling. The FGB is an independent authority. It is administratively attached to the FDJP."@en,
+        "La CFMJ surveille les maisons de jeu suisses, perçoit l'impôt sur les maisons de jeu et lutte contre le jeu d'argent illégal. La CFMJ est indépendante. Elle est administrativement rattachée au Département fédéral de justice et police."@fr,
+        "La CFCG vigila le case da gioco svizzere, riscuote la tassa sulle case da gioco e lotta contro i giochi in denaro illegali. La CFCG è indipendente. È aggregata amministrativamente al Dipartimento federale di giustizia e polizia."@it ;
+    dcterms:identifier "CH_ESBK" ;
+    skos:prefLabel "ESBK"@de,
+        "ESBK"@en,
+        "CFMJ"@fr,
+        "CFCG"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-ejpd> ;
+    foaf:homepage <https://www.esbk.admin.ch> ;
+    foaf:name "Eidgenössische Spielbankenkommission (ESBK)"@de,
+        "Eidgenössische Spielbankenkommission (ESBK)"@en,
+        "Commission fédérale des maisons de jeu (CFMJ)"@fr,
+        "Commissione federale delle case da gioco (CFCG)"@it .
+
+<https://www.esbk.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-estv.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-estv.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-estv> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ESTV" ;
+    skos:prefLabel "ESTV"@de,
+        "AFC"@en,
+        "AFC"@fr,
+        "FTA"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-efd> ;
+    foaf:name "Eidgenössische Steuerverwaltung (ESTV)"@de,
+        "Federal Tax Administration (AFC)"@en,
+        "Administration fédérale des contributions (AFC)"@fr,
+        "Amministrazione federale delle contribuzioni (FTA)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-eth-lib.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-eth-lib.ttl
@@ -1,0 +1,34 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-eth-lib> a org:Organization,
+        foaf:Organization ;
+    dcterms:description """Die ETH-Bibliothek ist die grösste öffentliche naturwissenschaftliche und technische Bibliothek der Schweiz. Die ETH-Bibliothek als zentrale Hochschulbibliothek und Wissenshub der ETH (Eidgenössische Technische Hochschule) Zürich stellt deren Versorgung mit naturwissenschaftlicher und technischer Information sicher. Darüber hinaus bietet sie auch Ressourcen für die Öffentlichkeit und für Firmen aus Forschung und Entwicklung.
+
+Quelle: Wikipedia (https://de.wikipedia.org/wiki/ETH-Bibliothek)"""@de,
+        """The ETH Library, serving as the central university library at ETH Zurich, has a notable collection of scientific and technical information. It is considered one of the largest public scientific and technical libraries in Switzerland. Furthermore, it offers resources for the public and companies in research and development.
+
+Source: Wikipedia (https://en.wikipedia.org/wiki/ETH_Library)"""@en,
+        """La bibliothèque de l'École polytechnique fédérale de Zurich (bibliothèque de l'EPFZ, en allemand ETH-Bibliothek) est une bibliothèque publique de Suisse consacrée à la technique et aux sciences naturelles, située à Zurich. Elle fait office à la fois de bibliothèque universitaire centralisée de l'EPFZ et de centre national d'information scientifique et technique. Accessible aux étudiants et aux enseignants, elle offre également des ressources au grand public ainsi qu’aux entreprises issues du secteur de la recherche et développement.
+
+Source: Wikipédia (https://fr.wikipedia.org/wiki/Biblioth%C3%A8que_de_l%27%C3%89cole_polytechnique_f%C3%A9d%C3%A9rale_de_Zurich)"""@fr,
+        """La biblioteca del Politecnico federale di Zurigo (ETH-Bibliothek Zürich), è la biblioteca pubblica di scienze naturali e tecnica più grande della Svizzera. La biblioteca dell'ETH è la biblioteca universitaria centrale del Politecnico stesso (Eidgenössische Technische Hochschule Zürich, ETH) nonché il centro nazionale di informazione in scienza naturale e tecnologia. Oltre a mettere a disposizione le informazioni per i membri dell'ETH, essa offre risorse anche per il pubblico interessato e per le imprese dei settori ricerca e sviluppo.
+
+Fonte: Wikipedia (https://it.wikipedia.org/wiki/Biblioteca_del_Politecnico_federale_di_Zurigo)"""@it ;
+    dcterms:identifier "CH_ETH_LIB" ;
+    skos:prefLabel "ETH"@de,
+        "ETH"@en,
+        "ETH"@fr,
+        "ETH"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-eth> ;
+    foaf:homepage <https://library.ethz.ch/> ;
+    foaf:name "ETH-Bibliothek"@de,
+        "ETH-Bibliothek"@en,
+        "ETH-Bibliothek"@fr,
+        "ETH-Bibliothek"@it .
+
+<https://library.ethz.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-eth.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-eth.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-eth> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die Eidgenössische Technische Hochschule Zürich (ETH Zürich) ist eine Hochschule mit technisch-naturwissenschaftlichem Fokus in Zürich."@de,
+        "The Swiss Federal Institute of Technology in Zurich (ETH Zurich) is a university with a technical and scientific focus in Zurich."@en,
+        "L'École polytechnique fédérale de Zurich (EPFZ) est une haute école spécialisée dans les sciences techniques et naturelles située à Zurich."@fr,
+        "Il Politecnico federale di Zurigo (ETH Zurigo) è un'università a indirizzo tecnico-scientifico con sede a Zurigo."@it ;
+    dcterms:identifier "CH_ETH" ;
+    skos:prefLabel "ETH Zürich"@de,
+        "ETH Zürich"@en,
+        "ETH Zürich"@fr,
+        "ETH Zürich"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0224> ;
+    foaf:homepage <https://www.ethz.ch> ;
+    foaf:name "ETH Zürich"@de,
+        "ETH Zürich"@en,
+        "ETH Zürich"@fr,
+        "ETH Zürich"@it .
+
+<https://www.ethz.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-fedpol.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-fedpol.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-fedpol> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_FEDPOL" ;
+    skos:prefLabel "fedpol"@de,
+        "fedpol"@en,
+        "fedpol"@fr,
+        "fedpol"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-ejpd> ;
+    foaf:name "Bundesamt für Polizei (fedpol)"@de,
+        "Federal Office of Polizei (fedpol)"@en,
+        "Office fédéral de Polizei (fedpol)"@fr,
+        "Ufficio federale di Polizei (fedpol)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-ge-fondationmodus.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-ge-fondationmodus.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-ge-fondationmodus> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_GE_FONDATIONMODUS" ;
+    skos:prefLabel "MODUS"@de,
+        "MODUS"@en,
+        "MODUS"@fr,
+        "MODUS"@it ;
+    foaf:name "FONDATION MODUS (GE)"@de,
+        "FONDATION MODUS (GE)"@en,
+        "FONDATION MODUS (GE)"@fr,
+        "FONDATION MODUS (GE)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gmde-glarus.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gmde-glarus.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gmde-glarus> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_GMDE_GLARUS" ;
+    skos:prefLabel "Gemeinde Glarus"@de,
+        "Commune Glarus"@en,
+        "Commune de Glaris"@fr,
+        "Communi di Glarona"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0223> ;
+    foaf:homepage <https://www.glarus.ch> ;
+    foaf:name "Gemeinde Glarus"@de,
+        "Commune Glarus"@en,
+        "Commune de Glaris"@fr,
+        "Communi di Glarona"@it .
+
+<https://www.glarus.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gogd.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gogd.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gogd> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_GOGD" ;
+    skos:prefLabel "OGD"@de,
+        "OGD"@en,
+        "OGD"@fr,
+        "OGD"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch1> ;
+    foaf:homepage <https://www.bfs.admin.ch/bfs/de/home/dienstleistungen/ogd/geschaeftsstelle.html> ;
+    foaf:name "Geschäftsstelle Open Government Data (OGD)"@de,
+        "Open Government Data Office (OGD)"@en,
+        "Secrétariat Open Government Data (OGD)"@fr,
+        "Segreteria Open Government Data (OGD)"@it .
+
+<https://www.bfs.admin.ch/bfs/de/home/dienstleistungen/ogd/geschaeftsstelle.html> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gs-edi.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gs-edi.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gs-edi> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_GS_EDI" ;
+    skos:prefLabel "GS-EDI"@de,
+        "GS-EDI"@en,
+        "SG-DFI"@fr,
+        "SG-DFI"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:name "Generalsekretariat des Eidgenössischen Departements des Innern (GS-EDI)"@de,
+        "General Secretariat of the Federal Department of Home Affairs (GS-EDI)"@en,
+        "Secrétariat général du Département fédéral de l'intérieur (SG-DFI)"@fr,
+        "Segreteria generale del Dipartimento federale dell'interno (SG-DFI)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gs-efd.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gs-efd.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gs-efd> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Bundesfinanzen, Finanzmarktstabilität, Steuern – beim EFD dreht sich vieles um den Staatshaushalt und um Finanzpolitik. Es nimmt Steuern und Zölle ein und kontrolliert den Personen- und Warenverkehr an der Grenze. Ausserdem erbringt es Dienstleistungen für die gesamte Bundesverwaltung, von der Informatik über das Personalwesen bis hin zu Bauten und Logistik."@de,
+        "Federal finances, financial market stability, taxes – at the FDF, there is a lot of emphasis on the state budget and on fiscal policy. The department collects taxes and customs duties, and checks the cross-border movement of people and goods. It also provides services for the entire Federal Administration, from IT to human resources to buildings and logistics."@en,
+        "Finances fédérales, stabilité des marchés financiers, fiscalité – la plupart des sujets traités au DFF concernent les finances de l’État et la politique budgétaire. Mais le DFF perçoit aussi les droits de douane et contrôle la circulation des personnes et des marchandises à la frontière. Il fournit aussi des prestations à l’ensemble de l’administration fédérale dans les domaines de l’informatique, des constructions et de la logistique ainsi que du personnel de la Confédération."@fr,
+        "Finanze federali, stabilità della piazza finanziaria, imposte: al DFF molto ruota attorno ai conti pubblici e alla politica finanziaria. Il Dipartimento riscuote imposte e dazi, controlla persone e merci alla frontiera, ma fornisce anche prestazioni di servizi a tutta l’Amministrazione federale, spaziando dall’informatica alle questioni relative al personale fino alla costruzione e alla logistica."@it ;
+    dcterms:identifier "CH_GS_EFD" ;
+    skos:prefLabel "GS-EFD"@de,
+        "GS-FDF"@en,
+        "SG-DFF"@fr,
+        "SG-DFF"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.efd.admin.ch> ;
+    foaf:name "Generalsekretariat EFD (GS-EFD)"@de,
+        "General Secretariat FDF (GS-FDF)"@en,
+        "Secrétariat général DFF (SG-DFF)"@fr,
+        "Segreteria generale DFF (SG-DFF)"@it .
+
+<https://www.efd.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gs-ejpd.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gs-ejpd.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gs-ejpd> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_GS_EJPD" ;
+    skos:prefLabel "GS-EJPD"@de,
+        "GS-FDJP"@en,
+        "SG-DFJP"@fr,
+        "SG-DFGP"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.ejpd.admin.ch/ejpd/de/home/das-ejpd/org/gs-ejpd.html> ;
+    foaf:name "Generalsekretariat Eidgenössisches Justiz- und Polizeidepartement (GS-EJPD)"@de,
+        "General Secretariat Federal Department of Justice and Police (GS-FDJP)"@en,
+        "Secrétariat général Département fédéral de justice et police (SG-DFJP)"@fr,
+        "Segreteria generale Dipartimento federale di giustizia e polizia (SG-DFGP)"@it .
+
+<https://www.ejpd.admin.ch/ejpd/de/home/das-ejpd/org/gs-ejpd.html> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gs-uvek.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gs-uvek.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gs-uvek> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das EDI ist verantwortlich für die sozialen, kulturellen und gesundheitlichen Belange der Schweiz. Zudem ist das EDI zuständig für die Gleichstellung von Frau und Mann und von Menschen mit Behinderungen, die Rassismusbekämpfung, die Statistiken des Bundes und die Meteorologie."@de,
+        "The Federal Department of Home Affairs is responsible for Switzerland’s social, cultural and health-related affairs. The FDHA is also responsible for gender equality, equality of people with disabilities, combating racism, federal statistics and meteorology. "@en,
+        "Le DFI est essentiellement en charge des questions sociales et culturelles, ainsi que des aspects touchant à la santé. L’égalité femmes-hommes, l’égalité des personnes handicapées, la lutte contre le racisme, les statistiques et les prévisions météorologiques font également partie de ses attributions. "@fr,
+        "Il DFI è responsabile delle questioni sociali, culturali e sanitarie della Svizzera. Rientrano nel suo ambito di competenza anche l’uguaglianza fra donna e uomo, le pari opportunità delle persone con disabilità, la lotta al razzismo, le statistiche federali e la meteorologia."@it ;
+    dcterms:identifier "CH_GS_UVEK" ;
+    skos:prefLabel "GS-UVEK"@de,
+        "GS-DETEC"@en,
+        "SG-DETEC"@fr,
+        "SG-DATEC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.edi.admin.ch> ;
+    foaf:name "Generalsekretariat des UVEK (GS-UVEK)"@de,
+        "General Secretariat DETEC (GS-DETEC)"@en,
+        "Secrétariat général du DETEC (SG-DETEC)"@fr,
+        "Segreteria generale del DATEC (SG-DATEC)"@it .
+
+<https://www.edi.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-gs-uvek.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gs-uvek.ttl
@@ -5,21 +5,21 @@
 
 <https://opendata.swiss/id/organization/ch-gs-uvek> a org:Organization,
         foaf:Organization ;
-    dcterms:description "Das EDI ist verantwortlich für die sozialen, kulturellen und gesundheitlichen Belange der Schweiz. Zudem ist das EDI zuständig für die Gleichstellung von Frau und Mann und von Menschen mit Behinderungen, die Rassismusbekämpfung, die Statistiken des Bundes und die Meteorologie."@de,
-        "The Federal Department of Home Affairs is responsible for Switzerland’s social, cultural and health-related affairs. The FDHA is also responsible for gender equality, equality of people with disabilities, combating racism, federal statistics and meteorology. "@en,
-        "Le DFI est essentiellement en charge des questions sociales et culturelles, ainsi que des aspects touchant à la santé. L’égalité femmes-hommes, l’égalité des personnes handicapées, la lutte contre le racisme, les statistiques et les prévisions météorologiques font également partie de ses attributions. "@fr,
-        "Il DFI è responsabile delle questioni sociali, culturali e sanitarie della Svizzera. Rientrano nel suo ambito di competenza anche l’uguaglianza fra donna e uomo, le pari opportunità delle persone con disabilità, la lotta al razzismo, le statistiche federali e la meteorologia."@it ;
+    dcterms:description "Das UVEK kümmert sich um die Stromversorgung, die Verkehrs- und Kommunikationsinfrastruktur, die Raumentwicklung und den Umweltschutz."@de,
+        "Across its seven federal offices, DETEC is responsible for a wide range of tasks, from ensuring a secure electricity supply through maintaining the transport and communications infrastructure, coordinating spatial development and protecting the environment."@en,
+        "Le DETEC s’occupe de différents thèmes : l’électricité, les transports, la communication, l’aménagement du territoire et l’environnement."@fr,
+        "Il DATEC si occupa di approvvigionamento elettrico, infrastrutture dei trasporti e della comunicazione, sviluppo territoriale e protezione dell’ambiente."@it ;
     dcterms:identifier "CH_GS_UVEK" ;
     skos:prefLabel "GS-UVEK"@de,
         "GS-DETEC"@en,
         "SG-DETEC"@fr,
         "SG-DATEC"@it ;
     org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
-    foaf:homepage <https://www.edi.admin.ch> ;
+    foaf:homepage <https://www.uvek.admin.ch> ;
     foaf:name "Generalsekretariat des UVEK (GS-UVEK)"@de,
         "General Secretariat DETEC (GS-DETEC)"@en,
         "Secrétariat général du DETEC (SG-DETEC)"@fr,
         "Segreteria generale del DATEC (SG-DATEC)"@it .
 
-<https://www.edi.admin.ch> a foaf:Document .
+<https://www.uvek.admin.ch> a foaf:Document .
 

--- a/opendata.swiss/metadata/piveau_organizations/ch-gs-vbs.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-gs-vbs.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-gs-vbs> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_GS_VBS" ;
+    skos:prefLabel "GS-VBS"@de,
+        "GS-DDPS"@en,
+        "SG-DDPS"@fr,
+        "SG-DDPS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.vbs.admin.ch> ;
+    foaf:name "Generalsekretariat Eidgenössisches Departement für Verteidigung, Bevölkerungsschutz und Sport VBS (GS-VBS)"@de,
+        "General Secretariat Federal Department of Defence, Civil Protection and Sport (GS-DDPS)"@en,
+        "Secrétariat général Département fédéral de la défense, de la protection de la population et de sports (SG-DDPS)"@fr,
+        "Segreteria generale Dipartimento federale della difesa, della protezione della popolazione e dello sport (SG-DDPS)"@it .
+
+<https://www.vbs.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-identitas.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-identitas.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-identitas> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_IDENTITAS" ;
+    skos:prefLabel "IDENTITAS AG"@de,
+        "IDENTITAS"@en,
+        "IDENTITAS SA"@fr,
+        "IDENTITAS"@it ;
+    foaf:name "IDENTITAS AG"@de,
+        "IDENTITAS"@en,
+        "IDENTITAS SA"@fr,
+        "IDENTITAS"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-ige.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-ige.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-ige> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_IGE" ;
+    skos:prefLabel "IGE"@de,
+        "IPI"@en,
+        "IPI"@fr,
+        "IPI"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-ejpd> ;
+    foaf:name "Eidgenössisches Institut für Geistiges Eigentum (IGE)"@de,
+        "Swiss Federal Institute of Intellectual Property (IPI)"@en,
+        "Institut Fédéral de la Propriété Intellectuelle (IPI)"@fr,
+        "Istituto Federale della Proprietà Intellettuale (IPI)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-innosuisse.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-innosuisse.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-innosuisse> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_INNOSUISSE" ;
+    skos:prefLabel "Schweizerische Agentur für Innovationsföderung Innosuisse"@de,
+        "Swiss Innovation Agency Innosuisse"@en,
+        "Agence suisse pour l’encouragement de l’innovation Innosuisse"@fr,
+        "Agenzia svizzera per la promozione dell'innovazione Innosuisse"@it ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:name "Schweizerische Agentur für Innovationsföderung Innosuisse"@de,
+        "Swiss Innovation Agency Innosuisse"@en,
+        "Agence suisse pour l’encouragement de l’innovation Innosuisse"@fr,
+        "Agenzia svizzera per la promozione dell'innovazione Innosuisse"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-isceco.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-isceco.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-isceco> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ISCECO" ;
+    skos:prefLabel "Information Service Center WBF ISCeco"@de,
+        "Information Service Center WBF ISCeco"@en,
+        "Centre de services informatiques du DEFR ISCeco"@fr,
+        "Centro servizi informatici DEFR ISCeco"@it ;
+    foaf:name "Information Service Center WBF ISCeco"@de,
+        "Information Service Center WBF ISCeco"@en,
+        "Centre de services informatiques du DEFR ISCeco"@fr,
+        "Centro servizi informatici DEFR ISCeco"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-it-logix.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-it-logix.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-it-logix> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_IT-Logix" ;
+    skos:prefLabel "IT-Logix"@de,
+        "IT-Logix"@en,
+        "IT-Logix"@fr,
+        "IT-Logix"@it ;
+    foaf:name "IT-Logix"@de,
+        "IT-Logix"@en,
+        "IT-Logix"@fr,
+        "IT-Logix"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kbob.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kbob.ttl
@@ -1,0 +1,23 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kbob> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Ressourcen sparen und Qualität steigernDies ist die übergeordnete Zielsetzung der KBOB.Die KBOB wahrt die Interessen ihrer Mitglieder als Bauherren sowie Liegenschaftseigentümer und -besitzer, -bewirtschafter und -betreiber.Als Mitglieder gehören der KBOB die Bau- und Liegenschaftsorgane des Bundes, der Kantone sowie der Städte und Gemeinden an.Die KBOB nimmt insbesondere Koordinationsaufgaben in folgenden Bereichen wahr: Beschaffungs- und Vertragswesen, Planer- und Werkleistungen, Nachhaltigkeit, Digitalisierung und BIM, Bewirtschaftung von Immobilien, Preisänderungsfragen sowie Normen und Standards."@de,
+        "Économiser les ressources tout en améliorant la qualitéTel est l'objectif général de la KBOB.La KBOB défend les intérêts de ses membres en tant que maîtres d'ouvrage, propriétaires, gérants et exploitants d'immeubles.Les membres de la KBOB sont les services de la construction et des immeubles de la Confédération, des cantons ainsi que des villes et des communes.La KBOB assume notamment des tâches de coordination dans les domaines suivants : marchés publics et contrats, prestations de mandataire et travaux de construction, durabilité, numérisation et BIM, exploitation des biens immobiliers, variations de prix ainsi que normes et standards."@fr,
+        "Risparmiare le risorse e migliorare la qualitàQuesto è l'obiettivo principale del KBOB.La KBOB tutela gli interessi dei suoi membri in quanto proprietari di edifici e immobili, gestori e operatori.I membri della KBOB comprendono le autorità edilizie e immobiliari della Confederazione, dei Cantoni, delle città e dei Comuni.In particolare, il KBOB svolge compiti di coordinamento nelle seguenti aree: appalti pubblici e contratti, prestazioni del mandatario e prestazioni d’opera, sostenibilità, digitalizzazione e BIM, gestione degli immobili, questioni relative a variazioni di prezzo, nonché norme e standard."@it ;
+    dcterms:identifier "CH_KBOB" ;
+    skos:prefLabel "KBOB"@de,
+        "KBOB"@en,
+        "KBOB"@fr,
+        "KBOB"@it ;
+    foaf:homepage <https://www.kbob.admin.ch> ;
+    foaf:name "Koordinationskonferenz der Bau- und Liegenschaftsorgane der öffentlichen Bauherren (KBOB)"@de,
+        "KBOB"@en,
+        "Conférence de coordination des services de la construction et des immeubles des maîtres d’ouvrage publics (KBOB)"@fr,
+        "Conferenza di coordinamento degli organi della costruzione e degli immobili dei committenti pubblici (KBOB)"@it .
+
+<https://www.kbob.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kora.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kora.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kora> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KORA" ;
+    skos:prefLabel "KORA"@de,
+        "KORA"@en,
+        "KORA"@fr,
+        "KORA"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0109> ;
+    foaf:name "KORA"@de,
+        "KORA"@en,
+        "KORA"@fr,
+        "KORA"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-ag.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-ag.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-ag> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_AG" ;
+    skos:prefLabel "AG"@de,
+        "AG"@en,
+        "AG"@fr,
+        "AG"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:name "Kanton Aargau AG"@de,
+        "Canton Aargau AG"@en,
+        "Canton d'Argovie AG"@fr,
+        "Canton Argovia AG"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-bern.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-bern.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-bern> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_BERN" ;
+    skos:prefLabel "Kanton Bern"@de,
+        "Kanton Bern"@en,
+        "Canton Berne"@fr,
+        "Kanton Bern"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:name "Kanton Bern"@de,
+        "Kanton Bern"@en,
+        "Canton Berne"@fr,
+        "Kanton Bern"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-bl.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-bl.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-bl> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_BL" ;
+    skos:prefLabel "BL"@de,
+        "BL"@en,
+        "BL"@fr,
+        "BL"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:homepage <https://www.baselland.ch> ;
+    foaf:name "Kanton Basel-Landschaft"@de,
+        "Canton Basel-Landschaft"@en,
+        "Canton Bâle-Campagne"@fr,
+        "Canton Basilea Campagna"@it .
+
+<https://www.baselland.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-bs.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-bs.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-bs> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_BS" ;
+    skos:prefLabel "Kt. BS"@de,
+        "Kt. BS"@en,
+        "Kt. BS"@fr,
+        "Kt. BS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:homepage <https://www.bs.ch> ;
+    foaf:name "Kanton Basel-Stadt"@de,
+        "Kanton Basel-Stadt"@en,
+        "Canton de Bâle-Ville"@fr,
+        "Cantone di Basilea Città"@it .
+
+<https://www.bs.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-fribourg.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-fribourg.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-fribourg> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_FRIBOURG" ;
+    skos:prefLabel "Kanton Freiburg"@de,
+        "Canton Fribourg"@en,
+        "Canton de Fribourg"@fr,
+        "Cantoni di Friburgo"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:name "Kanton Freiburg"@de,
+        "Canton Fribourg"@en,
+        "Canton de Fribourg"@fr,
+        "Cantoni di Friburgo"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-glarus.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-glarus.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-glarus> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_GLARUS" ;
+    skos:prefLabel "GL"@de,
+        "GL"@en,
+        "GL"@fr,
+        "GL"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:homepage <https://www.gl.ch> ;
+    foaf:name "Kanton Glarus GL"@de,
+        "Canton Glarus GL"@en,
+        "Canton de Glaris GL"@fr,
+        "Canton Glarona GL"@it .
+
+<https://www.gl.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-luzern-immobilien.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-luzern-immobilien.ttl
@@ -1,0 +1,23 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-luzern-immobilien> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die Dienststelle Immobilien ist das Immobilien-Kompetenzzentrum des Kantons Luzern. Sie vertritt als Eigentümerin und Bauherrin die Interessen des Kantons Luzern und betreibt ein innovatives und nachhaltiges Immobilienmanagement."@de ;
+    dcterms:identifier "CH_KT_LUZERN_IMMOBILIEN" ;
+    skos:prefLabel "Immobilien (LU)"@de,
+        "Real Estate (LU)"@en,
+        "Immobilier (LU)"@fr,
+        "Immobiliare (LU)"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-kt-luzern> ;
+    foaf:homepage <https://www.immobilien.lu.ch> ;
+    foaf:name "Dienststelle Immobilien Kanton Luzern"@de,
+        "Real Estate Office of the Canton of Lucerne"@en,
+        "Service immobilier du canton de Lucerne"@fr,
+        "Servizio immobiliare del Cantone di Lucerna"@it .
+
+<https://www.immobilien.lu.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-luzern-staatskanzlei.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-luzern-staatskanzlei.ttl
@@ -1,0 +1,23 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-luzern-staatskanzlei> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die Staatskanzlei unterstützt den Regierungsrat und den Kantonsrat in organisatorischer Hinsicht bei der Erfüllung der kantonalen Aufgaben und informiert die Öffentlichkeit über die Grundlagen, Organisation, Ziele und Tätigkeiten des Staates."@de ;
+    dcterms:identifier "CH_KT_LUZERN_STAATSKANZLEI" ;
+    skos:prefLabel "Staatskanzlei (LU)"@de,
+        "State Chancellery (LU)"@en,
+        "Chancellerie d'État (LU)"@fr,
+        "Cancelleria di Stato (LU)"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-kt-luzern> ;
+    foaf:homepage <https://www.lu.ch/verwaltung/staatskanzlei> ;
+    foaf:name "Staatskanzlei des Kantons Luzern"@de,
+        "State Chancellery of the Canton of Lucerne"@en,
+        "Chancellerie d'État du canton de Lucerne"@fr,
+        "Cancelleria di Stato del Cantone di Lucerna"@it .
+
+<https://www.lu.ch/verwaltung/staatskanzlei> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-luzern.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-luzern.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-luzern> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_LUZERN" ;
+    skos:prefLabel "LU"@de,
+        "LU"@en,
+        "LU"@fr,
+        "LU"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:homepage <https://www.lu.ch> ;
+    foaf:name "Kanton Luzern LU"@de,
+        "Canton Luzern LU"@en,
+        "Canton de Lucerne LU"@fr,
+        "Canton Lucerna LU"@it .
+
+<https://www.lu.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-kt-st-gallen.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-kt-st-gallen.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-kt-st-gallen> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_KT_ST_GALLEN" ;
+    skos:prefLabel "Kanton St-Gallen"@de,
+        "Canton St-Gallen"@en,
+        "Canton St-Gallen"@fr,
+        "Canton St-Gallen"@it ;
+    foaf:name "Kanton St-Gallen"@de,
+        "Canton St-Gallen"@en,
+        "Canton St-Gallen"@fr,
+        "Canton St-Gallen"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-lustat.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-lustat.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-lustat> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_LUSTAT" ;
+    skos:prefLabel "LUSTAT"@de,
+        "LUSTAT"@en,
+        "LUSTAT"@fr,
+        "LUSTAT"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0117> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-kt-luzern> ;
+    foaf:homepage <https://lustat.ch> ;
+    foaf:name "LUSTAT Statistik Luzern"@de,
+        "LUSTAT Statistik Luzern"@en,
+        "LUSTAT Statistik Luzern"@fr,
+        "LUSTAT Statistik Luzern"@it .
+
+<https://lustat.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-meteoschweiz.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-meteoschweiz.ttl
@@ -1,0 +1,4 @@
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<https://opendata.swiss/id/organization/ch-meteoschweiz> a foaf:Organization .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-meteoschweiz.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-meteoschweiz.ttl
@@ -1,4 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 
-<https://opendata.swiss/id/organization/ch-meteoschweiz> a foaf:Organization .
+<https://opendata.swiss/id/organization/ch-meteoschweiz> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_METEOSCHWEIZ" ;
+    skos:prefLabel "MeteoSchweiz"@de,
+        "MeteoSwiss"@en,
+        "MétéoSuisse"@fr,
+        "MeteoSvizzera"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.meteoschweiz.admin.ch> ;
+    foaf:name "MeteoSchweiz"@de,
+        "MeteoSwiss"@en,
+        "MétéoSuisse"@fr,
+        "MeteoSvizzera"@it .
+
+<https://www.meteoschweiz.admin.ch> a foaf:Document .
 

--- a/opendata.swiss/metadata/piveau_organizations/ch-nabibl.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-nabibl.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-nabibl> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_NABIBL" ;
+    skos:prefLabel "NB"@de,
+        "NL"@en,
+        "BN"@fr,
+        "BN"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-bak> ;
+    foaf:name "Schweizerische Nationalbibliothek (NB)"@de,
+        "Swiss National Library (NL)"@en,
+        "Bibliothèque nationale suisse (BN)"@fr,
+        "Biblioteca nazionale svizzera (BN)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-nadb.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-nadb.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-nadb> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_NADB" ;
+    skos:prefLabel "NaDB - Swiss Data Steward"@de,
+        "NaDB - Swiss Data Steward"@en,
+        "NaDB - Swiss Data Steward"@fr,
+        "NaDB - Swiss Data Steward"@it ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch1> ;
+    foaf:name "NaDB - Swiss Data Steward"@de,
+        "NaDB - Swiss Data Steward"@en,
+        "NaDB - Swiss Data Steward"@fr,
+        "NaDB - Swiss Data Steward"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-nkrs.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-nkrs.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-nkrs> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_NKRS" ;
+    skos:prefLabel "Nationale Krebsregistrierungsstelle (NKRS)"@de,
+        "National Agency for Cancer Registration (NACR)"@en,
+        "Organe national d'enregistrement du cancer (ONEC)"@fr,
+        "Servizio nazionale di registrazione dei tumori (SNRT)"@it ;
+    foaf:name "Nationale Krebsregistrierungsstelle (NKRS)"@de,
+        "National Agency for Cancer Registration (NACR)"@en,
+        "Organe national d'enregistrement du cancer (ONEC)"@fr,
+        "Servizio nazionale di registrazione dei tumori (SNRT)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-open-banking-project.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-open-banking-project.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-open-banking-project> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_OPEN_BANKING_PROJECT" ;
+    skos:prefLabel "OpenBankingProject.ch"@de,
+        "OpenBankingProject.ch"@en,
+        "OpenBankingProject.ch"@fr,
+        "OpenBankingProject.ch"@it ;
+    foaf:name "OpenBankingProject.ch"@de,
+        "OpenBankingProject.ch"@en,
+        "OpenBankingProject.ch"@fr,
+        "OpenBankingProject.ch"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-openparldata.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-openparldata.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-openparldata> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_OPENPARLDATA" ;
+    skos:prefLabel "OpenParlData.ch"@de,
+        "OpenParlData.ch"@en,
+        "OpenParlData.ch"@fr,
+        "OpenParlData.ch"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:name "OpenParlData.ch"@de,
+        "OpenParlData.ch"@en,
+        "OpenParlData.ch"@fr,
+        "OpenParlData.ch"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-postcom.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-postcom.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-postcom> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_POSTCOM" ;
+    skos:prefLabel "Eidgenössische Postkommission PostCom"@de,
+        "Federal Postal Services Commission PostCom"@en,
+        "Commission fédérale de la poste PostCom"@fr,
+        "Commissione federale delle poste PostCom"@it ;
+    foaf:name "Eidgenössische Postkommission PostCom"@de,
+        "Federal Postal Services Commission PostCom"@en,
+        "Commission fédérale de la poste PostCom"@fr,
+        "Commissione federale delle poste PostCom"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-sbfi.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-sbfi.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-sbfi> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das Staatssekretariat für Bildung, Forschung und Innovation ist das Kompetenzzentrum des Bundes für national und international ausgerichtete Fragen der BFI-Politik."@de,
+        "The State Secretariat for Education, Research and Innovation is the Swiss federal government's specialised agency for national and international matters concerning ERI policy."@en,
+        "Le Secrétariat d'État à la formation, à la recherche et à l'innovation est le centre de compétences de la Confédération pour les questions de portée nationale ou internationale relevant de la politique FRI."@fr,
+        "La Segreteria di Stato per la formazione, la ricerca e l'innovazione è il centro di competenza della Confederazione per le questioni nazionali e internazionali connesse alla politica in materia di FRI."@it ;
+    dcterms:identifier "CH_SBFI" ;
+    skos:prefLabel "SBFI"@de,
+        "SERI"@en,
+        "SEFRI"@fr,
+        "SEFRI"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:homepage <https://www.sbfi.admin.ch> ;
+    foaf:name "Staatssekretariat für Bildung, Forschung und Innovation (SBFI)"@de,
+        "State Secretariat for Education, Research and Innovation (SERI)"@en,
+        "Secrétariat d'État à la formation, à la recherche et à l'innovation (SEFRI)"@fr,
+        "Segreteria di Stato per la formazione, la ricerca e l'innovazione (SEFRI)"@it .
+
+<https://www.sbfi.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-sdbb.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-sdbb.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-sdbb> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das SDBB ist eine Institution der Schweizerischen Konferenz der kantonalen Erziehungsdirektoren EDK. Es erbringt für die Kantone und Verbundpartner Dienstleistungen in der Berufsbildung und der Berufs-, Studien- und Laufbahnberatung."@de ;
+    dcterms:identifier "CH_SDBB" ;
+    skos:prefLabel "SDBB"@de,
+        "SDBB"@en,
+        "SDBB"@fr,
+        "SDBB"@it ;
+    foaf:homepage <https://www.sdbb.ch> ;
+    foaf:name "SDBB"@de,
+        "SDBB"@en,
+        "SDBB"@fr,
+        "SDBB"@it .
+
+<https://www.sdbb.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-seco.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-seco.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-seco> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SECO" ;
+    skos:prefLabel "Staatssekretariat für Wirtschaft SECO"@de,
+        "State Secretariat for Economic Affairs SECO"@en,
+        "Secrétariat d'État à l'économie SECO"@fr,
+        "Segreteria di Stato dell'economia SECO"@it ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:name "Staatssekretariat für Wirtschaft SECO"@de,
+        "State Secretariat for Economic Affairs SECO"@en,
+        "Secrétariat d'État à l'économie SECO"@fr,
+        "Segreteria di Stato dell'economia SECO"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-sem.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-sem.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-sem> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SEM" ;
+    skos:prefLabel "SEM"@de,
+        "SEM"@en,
+        "SEM"@fr,
+        "SEM"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-ejpd> ;
+    foaf:name "Staatssekretariat für Migration (SEM)"@de,
+        "State Secretariat for Migration (SEM)"@en,
+        "Secrétariat d'État à Migration (SEM)"@fr,
+        "Segreteria di Stato per Migration (SEM)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-sfti.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-sfti.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-sfti> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SFTI" ;
+    skos:prefLabel "Swiss Fintech Innovations"@de,
+        "Swiss Fintech Innovations"@en,
+        "Swiss Fintech Innovations"@fr,
+        "Swiss Fintech Innovations"@it ;
+    foaf:name "Swiss Fintech Innovations"@de,
+        "Swiss Fintech Innovations"@en,
+        "Swiss Fintech Innovations"@fr,
+        "Swiss Fintech Innovations"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-smn.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-smn.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-smn> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SMN" ;
+    skos:prefLabel "SNM"@de,
+        "SNM"@en,
+        "MNS"@fr,
+        "MNS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.nationalmuseum.ch> ;
+    foaf:name "Schweizerisches Nationalmuseum (SNM)"@de,
+        "Swiss National Museum (SNM)"@en,
+        "Musée national suisse (MNS)"@fr,
+        "Museo nazionale svizzero (MNS)"@it .
+
+<https://www.nationalmuseum.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-snf.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-snf.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-snf> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Der Schweizerische Nationalfonds (SNF) fördert herausragende Forschung an Hochschulen und anderen Institutionen – von der Chemie über die Medizin bis zur Soziologie. Tausende von Teams schaffen Wissen für eine bessere Zukunft aller Menschen. Gemeinsam mit Partnern gestalten wir den Forschungsplatz Schweiz."@de,
+        "The Swiss National Science Foundation (SNSF) funds excellent research at universities and other institutions – from chemistry to medicine to sociology. Thousands of teams are generating knowledge for a better future for all. Together with our partners, we play a key role in shaping research in Switzerland."@en,
+        "Le Fonds national suisse (FNS) soutient la recherche de haut niveau dans les hautes écoles et d’autres institutions – de la chimie à la sociologie en passant par la médecine. Des milliers d’équipes créent des connaissances pour un avenir meilleur. Avec nos partenaires, nous façonnons la place scientifique suisse."@fr,
+        "Il Fondo nazionale svizzero per la ricerca scientifica (FNS) promuove la ricerca d’eccellenza presso le scuole universitarie e altre istituzioni: dalla chimica alla sociologia passando per la medicina. Sono migliaia i gruppi di ricerca impegnati nel creare il sapere necessario per garantire un futuro migliore all’umanità. Con i nostri partner istituzionali forgiamo la ricerca svizzera."@it ;
+    dcterms:identifier "CH_SNF" ;
+    skos:prefLabel "SNF"@de,
+        "SNSF"@en,
+        "FNS"@fr,
+        "FNS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0110> ;
+    foaf:homepage <https://www.fns-it.ch> ;
+    foaf:name "Schweizerischer Nationalfonds zur Förderung der wissenschaftlichen Forschung (SNF)"@de,
+        "Swiss National Science Foundation (SNSF)"@en,
+        "Fonds national suisse de la recherche scientifique (FNS)"@fr,
+        "Fondo nazionale svizzero per la ricerca scientifica (FNS)"@it .
+
+<https://www.fns-it.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-snm.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-snm.ttl
@@ -1,0 +1,27 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-snm> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Unter dem Dach des Schweizerischen Nationalmuseums sind drei Museen sowie das Sammlungszentrum in Affoltern am Albis vereint. Die Museen präsentieren Schweizer Geschichte von den Anfängen bis heute, und erschliessen – auch mit temporären Ausstellungen zu aktuellen Themen – die schweizerischen Identitäten und die Vielfalt der Geschichte und Kultur unseres Landes."@de,
+        "Under the auspices of the Swiss National Museum, three museums and our Collection Centre in Affoltern am Albis are brought together. The museums showcase the history of Switzerland from its beginnings up to the present day, giving an insight into the Swiss identity and the rich tapestry of our country’s history and culture, with temporary exhibitions covering issues of current interest."@en,
+        "Le Musée national suisse regroupe trois musées, ainsi que le Centre des collections à Affoltern am Albis. Les musées présentent l’histoire suisse de ses débuts jusqu’à nos jours et mettent en valeur les différentes identités suisses ainsi que la diversité de l’histoire et de la culture de notre pays, notamment par le biais d’expositions temporaires sur des thèmes actuels."@fr,
+        "Il Museo nazionale svizzero (MNS) riunisce sotto lo stesso tetto tre musei nonché il Centro delle collezioni di Affoltern am Albis. Con le loro mostre i musei presentano la storia della Svizzera dagli inizi ad oggi e valorizzano l’identità svizzera e la varietà storica e culturale del nostro Paese. Le mostre temporanee su temi attuali offrono ulteriori impressioni."@it,
+        "Sut il tetg dal Museum naziunal svizzer èn unids trais museums sco er il Center da collecziuns ad Affoltern am Albis. Ils museums preschentan l’istorgia svizra dal cumenzament fin oz e rendan accessiblas er cun exposiziuns temporaras davart temas actuals las identitads svizras e la diversitad da l’istorgia e da la cultura da noss pajais."@rm ;
+    dcterms:identifier "CH_SNM" ;
+    skos:prefLabel "SNM"@de,
+        "SNM"@en,
+        "MNS"@fr,
+        "MNS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0117> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:homepage <https://www.nationalmuseum.ch> ;
+    foaf:name "Schweizerisches Nationalmuseum (SNM)"@de,
+        "Swiss National Museum (SNM)"@en,
+        "Musée national suisse (MNS)"@fr,
+        "Museo nazionale svizzero (MNS)"@it .
+
+<https://www.nationalmuseum.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-sphn.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-sphn.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-sphn> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SPHN" ;
+    skos:prefLabel "Swiss Personalized Health Network"@de,
+        "Swiss Personalized Health Network"@en,
+        "Swiss Personalized Health Network"@fr,
+        "Swiss Personalized Health Network"@it ;
+    foaf:name "Swiss Personalized Health Network"@de,
+        "Swiss Personalized Health Network"@en,
+        "Swiss Personalized Health Network"@fr,
+        "Swiss Personalized Health Network"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-ssk.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-ssk.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-ssk> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SSK" ;
+    skos:prefLabel "SSK"@de,
+        "SSK"@en,
+        "CSI"@fr,
+        "CSI"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0224> ;
+    foaf:homepage <https://www.ssk-csi.ch> ;
+    foaf:name "Schweizerische Steuerkonferenz (SSK)"@de,
+        "Schweizerische Steuerkonferenz (SSK)"@en,
+        "Conférence suisse des impôts (CSI)"@fr,
+        "Conferenza svizzera delle imposte (CSI)"@it .
+
+<https://www.ssk-csi.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-stadt-bern.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-stadt-bern.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-stadt-bern> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_STADT_BERN" ;
+    skos:prefLabel "Stadt Bern"@de,
+        "City of Bern"@en,
+        "Ville de Berne"@fr,
+        "Città di Berna"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0223> ;
+    foaf:homepage <https://bern.ch> ;
+    foaf:name "Stadt Bern"@de,
+        "City of Bern"@en,
+        "Ville de Berne"@fr,
+        "Città di Berna"@it .
+
+<https://bern.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-stadt-biel-bienne.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-stadt-biel-bienne.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-stadt-biel-bienne> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_STADT_BIEL_BIENNE" ;
+    skos:prefLabel "Stadt Biel"@de,
+        "City of Biel"@en,
+        "Ville de Bienne"@fr,
+        "citta di Bienne"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0223> ;
+    foaf:homepage <https://www.biel-bienne.ch/> ;
+    foaf:name "Stadt Biel"@de,
+        "City of Biel"@en,
+        "Ville de Bienne"@fr,
+        "citta di Bienne"@it .
+
+<https://www.biel-bienne.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-sust.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-sust.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-sust> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SUST" ;
+    skos:prefLabel "SUST"@de,
+        "STSB"@en,
+        "SESE"@fr,
+        "SISI"@it ;
+    foaf:name "Schweizerische Sicherheitsuntersuchungsstelle (SUST)"@de,
+        "Swiss Transportation Safety Investigation Board (STSB)"@en,
+        "Service suisse d'enquête de sécurité (SESE)"@fr,
+        " Servizio d'inchiesta svizzero sulla sicurezza (SISI)"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-suva.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-suva.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-suva> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SUVA" ;
+    skos:prefLabel "Suva"@de,
+        "Suva"@en,
+        "Suva"@fr,
+        "Suva"@it ;
+    foaf:name "Suva"@de,
+        "Suva"@en,
+        "Suva"@fr,
+        "Suva"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-swiss-emobility.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-swiss-emobility.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-swiss-emobility> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Swiss eMobility unterstützt die Schaffung der politischen und institutionellen Grundlagen für die Entwicklung der Elektromobilität in der Schweiz. Wir treten für die Wahrung der Interessen unserer Mitglieder im Zusammenhang mit der Elektromobilität ein."@de,
+        "Swiss eMobility supports the creation of the political and institutional foundations for the development of electromobility in Switzerland. We stand up for the interests of our members in connection with electromobility."@en,
+        "Swiss eMobility soutient la création des bases politiques et institutionnelles pour le développement de la mobilité électrique en Suisse. Nous défendons les intérêts de nos membres en rapport avec l'électromobilité."@fr,
+        "Swiss eMobility sostiene la creazione delle basi politiche e istituzionali per lo sviluppo della mobilità elettrica in Svizzera. Difendiamo gli interessi dei nostri membri in relazione alla mobilità elettrica."@it ;
+    dcterms:identifier "CH_SWISS_EMOBILITY" ;
+    skos:prefLabel "Swiss eMobility"@de,
+        "Swiss eMobility"@en,
+        "Swiss eMobility"@fr,
+        "Swiss eMobility"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0109> ;
+    foaf:homepage <https://www.swiss-emobility.ch> ;
+    foaf:name "Swiss eMobility"@de,
+        "Swiss eMobility"@en,
+        "Swiss eMobility"@fr,
+        "Swiss eMobility"@it .
+
+<https://www.swiss-emobility.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-swissdrg.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-swissdrg.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-swissdrg> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die SwissDRG AG ist eine gemeinsame Institution der Leistungserbringer, der Versicherer und der Kantone im schweizerischen Gesundheitssystem."@de,
+        "SwissDRG AG is a joint institution of service providers, insurers and cantons in the Swiss healthcare system."@en,
+        "SwissDRG SA est une institution commune des fournisseurs de prestations, des assureurs et des cantons dans le système de santé Suisse."@fr,
+        "La SwissDRG SA è un’istituzione comune dei fornitori di prestazioni, degli assicuratori e dei cantoni nell’ambito del sistema sanitario nazionale svizzero."@it ;
+    dcterms:identifier "CH_SWISSDRG" ;
+    skos:prefLabel "SwissDRG AG"@de,
+        "SwissDRG AG"@en,
+        "SwissDRG SA"@fr,
+        "SwissDRG AG"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0106> ;
+    foaf:homepage <https://www.swissdrg.org> ;
+    foaf:name "SwissDRG AG"@de,
+        "SwissDRG AG"@en,
+        "SwissDRG SA"@fr,
+        "SwissDRG AG"@it .
+
+<https://www.swissdrg.org> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-swissmedic.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-swissmedic.ttl
@@ -1,0 +1,18 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-swissmedic> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_Swissmedic" ;
+    skos:prefLabel "Schweizerisches Heilmittelinstitut Swissmedic"@de,
+        "Swiss Agency for Therapeutic Products Swissmedic"@en,
+        "Institut suisse des produits thérapeutiques Swissmedic"@fr,
+        "Istituto svizzero per gli agenti terapeutici Swissmedic"@it ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-edi> ;
+    foaf:name "Schweizerisches Heilmittelinstitut Swissmedic"@de,
+        "Swiss Agency for Therapeutic Products Swissmedic"@en,
+        "Institut suisse des produits thérapeutiques Swissmedic"@fr,
+        "Istituto svizzero per gli agenti terapeutici Swissmedic"@it .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-swisstopo.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-swisstopo.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-swisstopo> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_SWISSTOPO" ;
+    skos:prefLabel "swisstopo"@de,
+        "swisstopo"@en,
+        "swisstopo"@fr,
+        "swisstopo"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-vbs> ;
+    foaf:homepage <https://www.swisstopo.ch> ;
+    foaf:name "Bundesamt für Landestopografie (swisstopo)"@de,
+        "Federal Office of Topography (swisstopo)"@en,
+        "Office fédéral de topographie (swisstopo)"@fr,
+        "Ufficio federale di topografia (swisstopo)"@it .
+
+<https://www.swisstopo.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-uepf.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-uepf.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-uepf> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_UEPF" ;
+    skos:prefLabel "ÜPF"@de,
+        "PTSS"@en,
+        "SCPT"@fr,
+        "SCPT"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-ejpd> ;
+    foaf:homepage <https://www.li.admin.ch> ;
+    foaf:name "Dienst Überwachung Post- und Fernmeldeverkehr (ÜPF)"@de,
+        "Post and Telecommunications Surveillance Service (PTSS)"@en,
+        "Service Surveillance de la correspondance par poste et télécommunication (SCPT)"@fr,
+        "Servizio Sorveglianza della corrispondenza postale e del traffico delle telecomunicazioni (SCPT)"@it .
+
+<https://www.li.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-ulag.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-ulag.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-ulag> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_ULAG" ;
+    skos:prefLabel "Uli Lippuner AG"@de,
+        "Uli Lippuner AG"@en,
+        "Uli Lippuner AG"@fr,
+        "Uli Lippuner AG"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0106> ;
+    foaf:homepage <https://www.ulippuner.ch> ;
+    foaf:name "Uli Lippuner AG"@de,
+        "Uli Lippuner AG"@en,
+        "Uli Lippuner AG"@fr,
+        "Uli Lippuner AG"@it .
+
+<https://www.ulippuner.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-unizh-foeg.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-unizh-foeg.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-unizh-foeg> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_UNIZH_FOEG" ;
+    skos:prefLabel "fög"@de,
+        "fög"@en,
+        "fög"@fr,
+        "fög"@it ;
+    foaf:name "Forschungszentrum Öffentlichkeit und Gesellschaft (fög)"@de,
+        "Research Center for the Public Sphere and Society (fög)"@en .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-vd-ocdc.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-vd-ocdc.ttl
@@ -1,0 +1,21 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-vd-ocdc> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_VD_OCDC" ;
+    skos:prefLabel "OCDC"@de,
+        "OCDC"@en,
+        "OCDC"@fr,
+        "OCDC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0221> ;
+    foaf:homepage <https://www.vd.ch/dadn/ocdc> ;
+    foaf:name "VD: Office cantonal de la durabilité et du climat OCDC"@de,
+        "VD: Office cantonal de la durabilité et du climat OCDC"@en,
+        "VD: Office cantonal de la durabilité et du climat OCDC"@fr,
+        "VD: Office cantonal de la durabilité et du climat OCDC"@it .
+
+<https://www.vd.ch/dadn/ocdc> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-vtg.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-vtg.ttl
@@ -1,0 +1,22 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-vtg> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "CH_VTG" ;
+    skos:prefLabel "Vtg"@de,
+        "Vtg"@en,
+        "Def"@fr,
+        "Dif"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-gs-vbs> ;
+    foaf:homepage <https://www.vtg.admin.ch> ;
+    foaf:name "Gruppe Verteidigung (Vtg)"@de,
+        "Defence sector (Vtg)"@en,
+        "Groupement Défense (Def)"@fr,
+        "Aggruppamento Difesa (Dif)"@it .
+
+<https://www.vtg.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-wbf.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-wbf.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-wbf> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Im WBF sind die Kompetenzen der Schweizer Regierung für alle Fragen zu Wirtschaftsangelegenheiten und Handelspolitik vereint. Verfolgen Sie unsere Strategie für Arbeit, Wachstum und Wohlstand in der Schweiz und zur Sicherung einer nachhaltigen Entwicklung. Das Departement fasst zudem die Bereiche Bildung, Forschung und Innovation zusammen. Diese sind grundlegend für unsere Gesellschaft und die wirtschaftliche Leistungsfähigkeit der Schweiz."@de,
+        "The EAER is where the federal government’s expertise on economic affairs and trade policy is concentrated. You can follow our strategy for employment, growth and prosperity in Switzerland and for securing sustainable development. Furthermore, the EAER combines education, research and innovation – three areas that are crucial for our society and for Switzerland’s economic performance."@en,
+        "Le DEFR est le centre de compétence du gouvernement suisse pour toutes les questions d'économie et de politique commerciale. Prenez connaissance de notre stratégie en matière d'emploi, de croissance et de prospérité en Suisse, et découvrez notre politique de développement durable. Le département chapeaute également la formation, la recherche et l'innovation, trois domaines fondamentaux pour notre société et l'économie de la Suisse."@fr,
+        "Il DEFR riunisce le competenze del governo svizzero per tutte le principali questioni in materia economica e di politica commerciale. Seguite la nostra strategia in materia di lavoro, crescita, benessere e sviluppo sostenibile in Svizzera. In seno al Dipartimento sono inoltre raggruppati i settori della formazione, della ricerca e dell'innovazione, fondamentali per la nostra società e per la produttività del nostro Paese."@it ;
+    dcterms:identifier "CH_WBF" ;
+    skos:prefLabel "WBF"@de,
+        "EAR"@en,
+        "DEFR"@fr,
+        "DEFR"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://www.wbf.admin.ch> ;
+    foaf:name "Eidgenössisches Departement für Wirtschaft, Bildung und Forschung (WBF)"@de,
+        "Federal Department of Economic Affairs, Education and Research (EAER)"@en,
+        "Département fédéral de l'économie, de la formation et de la recherche (DEFR)"@fr,
+        "Dipartimento federale dell'economia, della formazione e della ricerca (DEFR)"@it .
+
+<https://www.wbf.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-zas.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-zas.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-zas> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Die ZAS ist im Bereich der 1. Säule, welche die Alters- und Hinterlassenenversicherung AHV, die Invalidenversicherung IV und die Erwerbsersatzordnung EO umfasst, tätig."@de,
+        "The CCO is active in the field of 1st pillar social insurance: old-age and survivors' insurance OASI, disability insurance DI, compensation for loss of earnings APG."@en,
+        "La CdC est active dans le domaine des assurances sociales du 1er pilier : l’assurance-vieillesse et survivants AVS, l’assurance-invalidité AI et les allocations pour perte de gain APG."@fr,
+        "L’UCC è attivo nell’ambito del 1° pilastro: assicurazione vecchiaia e superstiti AVS, invalidità AI e assicurazione perdita di guadagno APG."@it ;
+    dcterms:identifier "CH_ZAS" ;
+    skos:prefLabel "ZAS"@de,
+        "CdC"@en,
+        "CdC"@fr,
+        "UCC"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-efv> ;
+    foaf:homepage <https://www.zas.admin.ch> ;
+    foaf:name "Zentrale Ausgleichsstelle (ZAS)"@de,
+        "Centrale de compensation (CdC)"@en,
+        "Centrale de compensation (CdC)"@fr,
+        "Ufficio centrale di compensazione (UCC)"@it .
+
+<https://www.zas.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch-zivi.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch-zivi.ttl
@@ -1,0 +1,26 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch-zivi> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das Bundesamt für Zivildienst (ZIVI) ist die zuständige Behörde des Bundes für alle Belange des Zivildienstes."@de,
+        "The Federal Office for Civilian Service (ZIVI) is the federal authority responsible for all matters relating to civilian service."@en,
+        "Autorité de la Confédération responsable de toutes les questions relatives au service civil."@fr,
+        "L’Ufficio federale del servizio civile (CIVI) è l’autorità competente della Confederazione per tutte le questioni concernenti il servizio civile."@it ;
+    dcterms:identifier "CH_ZIVI" ;
+    skos:prefLabel "ZIVI"@de,
+        "ZIVI"@en,
+        "CIVI"@fr,
+        "CIVI"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    org:subOrganizationOf <https://opendata.swiss/id/organization/ch-wbf> ;
+    foaf:homepage <https://www.zivi.admin.ch/> ;
+    foaf:name "Bundesamt für Zivildienst (ZIVI)"@de,
+        "Federal Office of Zivildienst (CIVI)"@en,
+        "Office fédéral du service civil (CIVI)"@fr,
+        "Ufficio federale del servizio civile (CIVI)"@it .
+
+<https://www.zivi.admin.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/ch1.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/ch1.ttl
@@ -1,0 +1,25 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/ch1> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das BFS ist das nationale Kompetenzzentrum der öffentlichen Statistik der Schweiz. Es produziert und publiziert statistische Informationen über den Stand und die Entwicklung von Bevölkerung, Wirtschaft, Gesellschaft, Bildung, Forschung, Raum und Umwelt. Diese Informationen dienen der Meinungsbildung in der Bevölkerung sowie der Planung und Steuerung von zentralen Politikbereichen. Sie leisten einen wichtigen Beitrag für einen modernen, demokratischen Staat."@de,
+        "The FSO is Switzerland's national competence centre for official statistics. It produces and publishes statistical information on the status and development of the population, economy, society, education, research, territory and the environment. This information is used for opinion building among the population and for the planning and management of key policy areas. They make an important contribution to a modern, democratic state."@en,
+        "L'OFS est le centre de compétence de la statistique publique suisse. Il produit des informations statistiques sur la population, l'économie, la société, la formation et la recherche, le territoire et l'environnement. Ces informations servent à la formation de l’opinion publique. Elles sont un outil de planification et de gouvernance dans tous les domaines de l’action politique et contribuent au bon fonctionnement de notre État moderne et démocratique."@fr,
+        "L’UST è il centro di competenza nazionale per la statistica pubblica della Svizzera. Produce e pubblica informazioni statistiche sullo stato e sull'evoluzione della popolazione, dell'economia, della società, della formazione, della ricerca, del territorio e dell'ambiente. Queste informazioni servono alla formazione dell'opinione pubblica nonché alla pianificazione e alla gestione in ambiti politici di centrale importanza. Forniscono un importante contributo per uno Stato moderno e democratico."@it ;
+    dcterms:identifier "CH1" ;
+    skos:prefLabel "BFS"@de,
+        "FSO"@en,
+        "OFS"@fr,
+        "UFS"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0220> ;
+    foaf:homepage <https://bfs.admin.ch> ;
+    foaf:name "Bundesamt für Statistik (BFS)"@de,
+        "Federal Statistical Office (FSO)"@en,
+        "Office Fédéral de la Statistique (OFS)"@fr,
+        "Ufficio federale di statistica (UFS)"@it .
+
+<https://bfs.admin.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-105-834-378.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-105-834-378.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-105-834-378> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Universitats-Kinderspital Zurich"@en ;
+    dcterms:identifier "CHE-105.834.378" ;
+    skos:prefLabel "Universitats-Kinderspital Zurich"@en ;
+    foaf:homepage <https://www.kispi.uzh.ch> ;
+    foaf:name "Universitats-Kinderspital Zurich"@en .
+
+<https://www.kispi.uzh.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-107-148-124.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-107-148-124.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-107-148-124> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Kinder und Jugendmedizin Koniz"@en ;
+    dcterms:identifier "CHE-107.148.124" ;
+    skos:prefLabel "Kinder und Jugendmedizin Koniz"@en ;
+    foaf:homepage <https://www.kjmk.ch> ;
+    foaf:name "Kinder und Jugendmedizin Koniz"@en .
+
+<https://www.kjmk.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-108-904-325.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-108-904-325.ttl
@@ -1,0 +1,23 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-108-904-325> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Das USZ steht jeden Tag allen Menschen offen und bietet medizinische Grundversorgung und Spitzenmedizin an zentraler Lage in Zürich."@de,
+        "The USZ is open to everyone every day and provides primary health care and cutting-edge medicine at the heart of Zurich."@en ;
+    dcterms:identifier "CHE-108.904.325" ;
+    skos:prefLabel "Universitätsspital Zürich"@de,
+        "USZ"@en,
+        "USZ"@fr,
+        "USZ"@it ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0234> ;
+    foaf:homepage <https://www.usz.ch> ;
+    foaf:name "Universitätsspital Zürich"@de,
+        "Universitätsspital Zürich"@en,
+        "Universitätsspital Zürich"@fr,
+        "Universitätsspital Zürich"@it .
+
+<https://www.usz.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-108-906-206.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-108-906-206.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-108-906-206> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Ostschweizer Kantonspital"@en ;
+    dcterms:identifier "CHE-108.906.206" ;
+    skos:prefLabel "Ostschweizer Kantonspital"@en ;
+    foaf:homepage <https://www.h-och.ch> ;
+    foaf:name "Ostschweizer Kantonspital"@en .
+
+<https://www.h-och.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-108-907-884.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-108-907-884.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-108-907-884> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Hopitaux universitaires de Geneve"@en ;
+    dcterms:identifier "CHE-108.907.884" ;
+    skos:prefLabel "Hopitaux universitaires de Geneve"@en ;
+    foaf:homepage <https://www.hug.ch> ;
+    foaf:name "Hopitaux universitaires de Geneve"@en .
+
+<https://www.hug.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-108-910-225.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-108-910-225.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-108-910-225> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Centre hospitalier universitaire vaudois"@en ;
+    dcterms:identifier "CHE-108.910.225" ;
+    skos:prefLabel "Centre hospitalier universitaire vaudois"@en ;
+    foaf:homepage <https://www.chuv.ch> ;
+    foaf:name "Centre hospitalier universitaire vaudois"@en .
+
+<https://www.chuv.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-109-329-783.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-109-329-783.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-109-329-783> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Luzerner Kantonsspital"@en ;
+    dcterms:identifier "CHE-109.329.783" ;
+    skos:prefLabel "Luzerner Kantonsspital"@en ;
+    foaf:homepage <https://www.luks.ch> ;
+    foaf:name "Luzerner Kantonsspital"@en .
+
+<https://www.luks.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-112-453-018.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-112-453-018.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-112-453-018> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Universitats-Kinderspital beider Basel"@en ;
+    dcterms:identifier "CHE-112.453.018" ;
+    skos:prefLabel "Universitats-Kinderspital beider Basel"@en ;
+    foaf:homepage <https://www.ukbb.ch> ;
+    foaf:name "Universitats-Kinderspital beider Basel"@en .
+
+<https://www.ukbb.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-115-173-213.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-115-173-213.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-115-173-213> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Universitatsspital Basel"@en ;
+    dcterms:identifier "CHE-115.173.213" ;
+    skos:prefLabel "Universitatsspital Basel"@en ;
+    foaf:homepage <https://www.unispital-basel.ch> ;
+    foaf:name "Universitatsspital Basel"@en .
+
+<https://www.unispital-basel.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-134-885-283.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-134-885-283.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-134-885-283> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Youkidoc Kindergesundheit"@en ;
+    dcterms:identifier "CHE-134.885.283" ;
+    skos:prefLabel "Youkidoc Kindergesundheit"@en ;
+    foaf:homepage <https://www.youkidoc.ch> ;
+    foaf:name "Youkidoc Kindergesundheit"@en .
+
+<https://www.youkidoc.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-183-020-319.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-183-020-319.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-183-020-319> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Centre Medicale Qorpus Hirslanden"@en ;
+    dcterms:identifier "CHE-183.020.319" ;
+    skos:prefLabel "Centre Medicale Qorpus Hirslanden"@en ;
+    foaf:homepage <https://www.hirslanden.ch/en/clinique-des-grangettes/centres-et-instituts/qorpus-medical-center.html> ;
+    foaf:name "Centre Medicale Qorpus Hirslanden"@en .
+
+<https://www.hirslanden.ch/en/clinique-des-grangettes/centres-et-instituts/qorpus-medical-center.html> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/che-229-707-417.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/che-229-707-417.ttl
@@ -1,0 +1,15 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/che-229-707-417> a org:Organization,
+        foaf:Organization ;
+    dcterms:description "Inselspital - Universitatsspital Bern"@en ;
+    dcterms:identifier "CHE-229.707.417" ;
+    skos:prefLabel "Inselspital - Universitatsspital Bern"@en ;
+    foaf:homepage <https://www.insel.ch> ;
+    foaf:name "Inselspital - Universitatsspital Bern"@en .
+
+<https://www.insel.ch> a foaf:Document .
+

--- a/opendata.swiss/metadata/piveau_organizations/i14y-test-organisation.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/i14y-test-organisation.ttl
@@ -1,0 +1,19 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/i14y-test-organisation> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "i14y-test-organisation" ;
+    skos:prefLabel "I14Y Test Organisation_de"@de,
+        "I14Y Test Organisation_en"@en,
+        "I14Y Test Organisation_fr"@fr,
+        "I14Y Test Organisation_it"@it,
+        "I14Y Test Organisation_rm"@rm ;
+    foaf:name "I14Y Test Organisation_de"@de,
+        "I14Y Test Organisation_en"@en,
+        "I14Y Test Organisation_fr"@fr,
+        "I14Y Test Organisation_it"@it,
+        "I14Y Test Organisation_rm"@rm .
+

--- a/opendata.swiss/metadata/piveau_organizations/unisante.ttl
+++ b/opendata.swiss/metadata/piveau_organizations/unisante.ttl
@@ -1,0 +1,17 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix org: <http://www.w3.org/ns/org#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://opendata.swiss/id/organization/unisante> a org:Organization,
+        foaf:Organization ;
+    dcterms:identifier "Unisante" ;
+    skos:prefLabel "Center for Primary Care and Public Health (Unisanté), University of Lausanne, Switzerland"@en,
+        "Centre universitaire de médecine générale et santé publique (Unisanté), Université de Lausanne, Suisse"@fr ;
+    org:classification <https://register.ld.admin.ch/i14y/concept/legalForm/0107> ;
+    foaf:homepage <https://www.unisante.ch/> ;
+    foaf:name "Center for Primary Care and Public Health (Unisanté), University of Lausanne, Switzerland"@en,
+        "Centre universitaire de médecine générale et santé publique (Unisanté), Université de Lausanne, Suisse"@fr .
+
+<https://www.unisante.ch/> a foaf:Document .
+

--- a/opendata.swiss/metadata/scripts/organizations.sh
+++ b/opendata.swiss/metadata/scripts/organizations.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Automatically export all variables
+set -a
+. ./.env
+set +a
+
+set -eu
+
+ORG_NAME="${1:-}"
+if [ -z "$ORG_NAME" ]; then
+  echo "No organization name provided, uploading all organizations..."
+  for file in piveau_organizations/*.ttl; do
+    echo "Uploading $(basename "$file") to ${HUB_REPO_ENDPOINT}/organizations/$(basename "$file" .ttl)"
+    curl -i -X PUT -H "X-API-Key: ${PIVEAU_HUB_API_KEY}" -H "Content-Type: text/turtle" --data @"$file" "${HUB_REPO_ENDPOINT}/organizations/$(basename "$file" .ttl)"
+  done
+else   
+    echo "Uploading ${ORG_NAME} to ${HUB_REPO_ENDPOINT}/organizations/${ORG_NAME}"
+    curl -i -X PUT -H "X-API-Key: ${PIVEAU_HUB_API_KEY}" -H "Content-Type: text/turtle" --data @"piveau_organizations/${ORG_NAME}.ttl" "${HUB_REPO_ENDPOINT}/organizations/${ORG_NAME}"
+fi

--- a/opendata.swiss/metadata/scripts/organizations_delete.sh
+++ b/opendata.swiss/metadata/scripts/organizations_delete.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Automatically export all variables
+set -a
+. ./.env
+set +a
+
+set -eu
+
+ORG_NAME="${1:-}"
+if [ -z "$ORG_NAME" ]; then
+  echo "No organization name provided, deleting all organizations..."
+  for file in piveau_organizations/*.ttl; do
+    echo "Deleting ${HUB_REPO_ENDPOINT}/organizations/$(basename "$file" .ttl)"
+    curl -i -X DELETE -H "X-API-Key: ${PIVEAU_HUB_API_KEY}" "${HUB_REPO_ENDPOINT}/organizations/$(basename "$file" .ttl)"
+  done 
+else   
+    echo "Deleting ${HUB_REPO_ENDPOINT}/organizations/${ORG_NAME}"
+    curl -i -X DELETE -H "X-API-Key: ${PIVEAU_HUB_API_KEY}" "${HUB_REPO_ENDPOINT}/organizations/${ORG_NAME}"
+fi


### PR DESCRIPTION
Adds a new CLI command to the Meta-Harvester: `generate-all-organizations`
Fetches all organizations from I14Y and generates the organization definition files in the `piveau_organizations/` directory. 

```
2026-05-07 12:22:48,990 - INFO - Collected 123 organization(s) from I14Y.
2026-05-07 12:22:48,991 - INFO - (1/123) Processing organization 'ch-babs'...
2026-05-07 12:22:49,002 - INFO - Successfully generated RDF triples and saved to '../piveau_organizations/ch-babs.ttl'
2026-05-07 12:22:49,002 - INFO - (2/123) Processing organization 'ch-bag'...
2026-05-07 12:22:49,005 - INFO - Successfully generated RDF triples and saved to '../piveau_organizations/ch-bag.ttl'
...
```

This PR does not touch on the catalogs. In a follow-up step, I will link some of the catalogs to some of these organizations (using "dcterms:publisher")


<img width="1824" height="928" alt="image" src="https://github.com/user-attachments/assets/328eb205-7148-4ca7-aefe-d70c380002d3" />
