### PR TITLE
Subscriptions

### DIFF
--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -42,6 +42,10 @@ jobs:
           repository: ${{ vars.CMS_REPO_TEST }}
           path: opendata.swiss/ui/content
 
+      - name: Prepare piveau backend env
+        working-directory: opendata.swiss/metadata
+        run: cp .env.example .env
+
       - name: Start listmonk
         run: docker compose up -d listmonk-app listmonk-init
         working-directory: opendata.swiss/metadata

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -42,6 +42,10 @@ jobs:
           repository: ${{ vars.CMS_REPO_TEST }}
           path: opendata.swiss/ui/content
 
+      - name: Start listmonk
+        run: docker compose up -d listmonk-app listmonk-init
+        working-directory: opendata.swiss/metadata
+
       - uses: fabasoad/setup-prolog-action@v1
 
       - uses: actions/setup-node@v6
@@ -51,7 +55,7 @@ jobs:
       - run: npm ci
         working-directory: opendata.swiss/ui
 
-      - run: npm run dev &
+      - run: sh ../metadata/listmonk/install.sh; npm run dev &
         working-directory: opendata.swiss/ui
         env:
           NUXT_API_TUNER_TESTS: true

--- a/.github/workflows/test-ui.yaml
+++ b/.github/workflows/test-ui.yaml
@@ -47,7 +47,7 @@ jobs:
         run: cp .env.example .env
 
       - name: Start listmonk
-        run: docker compose up -d listmonk-app listmonk-init
+        run: docker compose up -d listmonk-app listmonk-init mailpit
         working-directory: opendata.swiss/metadata
 
       - uses: fabasoad/setup-prolog-action@v1

--- a/opendata.swiss/metadata/.env.example
+++ b/opendata.swiss/metadata/.env.example
@@ -38,3 +38,11 @@ VITE_AUTHENTICATION_KEYCLOAK_CLIENT_ID="piveau-hub-ui"
 HUB_REPO_ENDPOINT="http://localhost:8081"
 CONSUS_SCHEDULING_ENDPOINT="http://localhost:8090"
 PIVEAU_METRICS_CACHE_ENDPOINT="http://localhost:8185"
+
+LISTMONK_ADMIN_USER="admin"
+LISTMONK_ADMIN_PASSWORD="password"
+LISTMONK_ADMIN_API_USER="admin-api"
+
+# Mailpit
+MAILPIT_WEB_URL="http://localhost:8025"
+MAILPIT_SMTP_URL="smtp://localhost:1025"

--- a/opendata.swiss/metadata/.gitignore
+++ b/opendata.swiss/metadata/.gitignore
@@ -2,3 +2,4 @@
 .env.*
 !.env.example
 volumes/
+listmonk/install.sh

--- a/opendata.swiss/metadata/README.md
+++ b/opendata.swiss/metadata/README.md
@@ -107,6 +107,19 @@ To remove a single catalogue (for example, `bl-dcat`), run:
 ./scripts/catalogues_delete.sh bl-dcat
 ```
 
+#### Listmonk initialization
+
+By default, the local Listmonk instance is configured with `admin/admin` superuser credentials and an API user `admin-api`.
+These can be changed by changing envirnment variables in `.env` file:
+
+```dotenv
+LISTMONK_ADMIN_USER=
+LISTMONK_ADMIN_PASSWORD=
+LISTMONK_ADMIN_API_USER=
+````
+
+On the first start, the stack will bootstrap Listmonk with content from the [listmonk](/listmonk) directory.
+
 To stop the stack, run:
 
 ```sh

--- a/opendata.swiss/metadata/README.md
+++ b/opendata.swiss/metadata/README.md
@@ -109,7 +109,7 @@ To remove a single catalogue (for example, `bl-dcat`), run:
 
 #### Listmonk
 
-By default, the local Listmonk instance is configured with `admin/admin` superuser credentials and an API user `admin-api`.
+By default, the local Listmonk instance is configured with `admin/password` superuser credentials and an API user `admin-api`.
 These can be changed by changing envirnment variables in `.env` file:
 
 ```dotenv

--- a/opendata.swiss/metadata/README.md
+++ b/opendata.swiss/metadata/README.md
@@ -107,7 +107,7 @@ To remove a single catalogue (for example, `bl-dcat`), run:
 ./scripts/catalogues_delete.sh bl-dcat
 ```
 
-#### Listmonk initialization
+#### Listmonk
 
 By default, the local Listmonk instance is configured with `admin/admin` superuser credentials and an API user `admin-api`.
 These can be changed by changing envirnment variables in `.env` file:
@@ -119,6 +119,8 @@ LISTMONK_ADMIN_API_USER=
 ````
 
 On the first start, the stack will bootstrap Listmonk with content from the [listmonk](/listmonk) directory.
+
+All emails sent by Listmonk will be caught by the mailpit instance, which is available at [http://localhost:8025](http://localhost:8025).
 
 To stop the stack, run:
 

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -413,7 +413,7 @@ services:
     hostname: listmonk.example.com                            # Recommend using FQDN for hostname
     depends_on:
       - listmonk-db
-    command: [sh, -c, "./listmonk --install --idempotent --yes --config '' 2> /listmonk/uploads/install.log && ./listmonk --upgrade --yes --config '' && ./listmonk --config ''"]
+    command: [sh, -c, "./listmonk --install --idempotent --yes --config '' 2> /listmonk/uploads/install.sh && ./listmonk --upgrade --yes --config '' && ./listmonk --config ''"]
       # --config (file) param is set to empty so that listmonk only uses the env vars (below) for config.
       # --install --idempotent ensures that DB installation happens only once on an empty DB, on the first ever start.
       # --upgrade automatically runs any DB migrations when a new image is pulled.

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -437,7 +437,7 @@ services:
       LISTMONK_ADMIN_API_USER: ${LISTMONK_ADMIN_API_USER:-admin-api}
       TZ: Etc/UTC
     volumes:
-      - ./uploads:/listmonk/uploads:rw                        # Mount an uploads directory on the host to /listmonk/uploads inside the container.
+      - ./listmonk:/listmonk/uploads:rw                        # Mount an uploads directory on the host to /listmonk/uploads inside the container.
       # To use this, change directory path in Admin -> Settings -> Media to /listmonk/uploads
 
   # listmonk init
@@ -448,7 +448,6 @@ services:
       - listmonk-app
     volumes:
       - ./listmonk:/init
-      - ./uploads:/uploads:ro
     env_file:
       - .env
     command: >

--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -1,3 +1,8 @@
+x-db-credentials: &db-credentials                             # Use the default POSTGRES_ credentials if they're available or simply default to "listmonk"
+  POSTGRES_USER: &db-user listmonk                            # for database user, password, and database name
+  POSTGRES_PASSWORD: &db-password listmonk
+  POSTGRES_DB: &db-name listmonk
+
 services:
   piveau-hub-repo:
     image: piveau/hub-repo:3.5.0
@@ -393,3 +398,97 @@ services:
     logging:
       options:
         max-size: "50m"
+
+  ####################
+  # Listmonk         #
+  ####################
+
+  # listmonk app
+  listmonk-app:
+    image: listmonk/listmonk:latest
+    container_name: listmonk_app
+    restart: unless-stopped
+    ports:
+      - "9000:9000"                                           # To change the externally exposed port, change to: $custom_port:9000
+    hostname: listmonk.example.com                            # Recommend using FQDN for hostname
+    depends_on:
+      - listmonk-db
+    command: [sh, -c, "./listmonk --install --idempotent --yes --config '' 2> /listmonk/uploads/install.log && ./listmonk --upgrade --yes --config '' && ./listmonk --config ''"]
+      # --config (file) param is set to empty so that listmonk only uses the env vars (below) for config.
+      # --install --idempotent ensures that DB installation happens only once on an empty DB, on the first ever start.
+      # --upgrade automatically runs any DB migrations when a new image is pulled.
+
+
+    env_file:
+      - .env
+    environment:                                              # The same params as in config.toml are passed as env vars here.
+      LISTMONK_app__address: 0.0.0.0:9000
+      LISTMONK_db__user: *db-user
+      LISTMONK_db__password: *db-password
+      LISTMONK_db__database: *db-name
+      LISTMONK_db__host: listmonk-db
+      LISTMONK_db__port: 5432
+      LISTMONK_db__ssl_mode: disable
+      LISTMONK_db__max_open: 25
+      LISTMONK_db__max_idle: 25
+      LISTMONK_db__max_lifetime: 300s
+      LISTMONK_ADMIN_USER: ${LISTMONK_ADMIN_USER:-admin}
+      LISTMONK_ADMIN_PASSWORD: ${LISTMONK_ADMIN_PASSWORD:-password}
+      LISTMONK_ADMIN_API_USER: ${LISTMONK_ADMIN_API_USER:-admin-api}
+      TZ: Etc/UTC
+    volumes:
+      - ./uploads:/listmonk/uploads:rw                        # Mount an uploads directory on the host to /listmonk/uploads inside the container.
+      # To use this, change directory path in Admin -> Settings -> Media to /listmonk/uploads
+
+  # listmonk init
+  listmonk-init:
+    image: alpine:latest
+    container_name: listmonk_init
+    depends_on:
+      - listmonk-app
+    volumes:
+      - ./listmonk:/init
+      - ./uploads:/uploads:ro
+    env_file:
+      - .env
+    command: >
+      sh -c "
+        apk add --no-cache curl jq &&
+        chmod +x /init/init-listmonk.sh &&
+        /init/init-listmonk.sh
+      "
+
+  # Postgres database
+  listmonk-db:
+    image: postgres:17-alpine
+    container_name: listmonk_db
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:5432:5432"                                 # Only bind on the local interface. To connect to Postgres externally, change this to 0.0.0.0
+    environment:
+      <<: *db-credentials
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U listmonk"]
+      interval: 10s
+      timeout: 5s
+      retries: 6
+    volumes:
+      - ./volumes/listmonk-data:/var/lib/postgresql/data
+
+  # SMTP server for development/testing
+  mailpit:
+    image: axllent/mailpit:latest
+    container_name: mailpit
+    restart: unless-stopped
+    ports:
+      - "8025:8025"
+      - "1025:1025"
+    environment:
+      MP_MAX_MESSAGES: 500
+      MP_DATABASE: /data/mailpit.db
+      MP_SMTP_AUTH_ACCEPT_ANY: "true"
+      MP_SMTP_AUTH_ALLOW_INSECURE: "true"
+    volumes:
+      - ./volumes/mailpit-data:/data
+
+

--- a/opendata.swiss/metadata/listmonk/init-listmonk.sh
+++ b/opendata.swiss/metadata/listmonk/init-listmonk.sh
@@ -192,6 +192,50 @@ delete_default_subscribers() {
   done
 }
 
+# Function to configure SMTP
+configure_smtp() {
+  echo "Configuring SMTP to use Mailpit..."
+
+  # Fetch current settings
+  SETTINGS_JSON=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/settings")
+
+  if [ -z "$SETTINGS_JSON" ] || [ "$SETTINGS_JSON" = "null" ]; then
+    echo "Error: Could not fetch current settings."
+    return
+  fi
+
+  # Update the SMTP configuration in the settings JSON
+  # We need to extract the .data object because Listmonk returns settings wrapped in .data
+  # and the PUT /api/settings expects the object that contains the keys to update.
+
+  # Mailpit configuration
+  MAILPIT_SMTP='{
+    "uuid": "default",
+    "name": "Mailpit",
+    "host": "mailpit",
+    "port": 1025,
+    "auth_protocol": "none",
+    "hello_hostname": "localhost",
+    "max_conns": 10,
+    "idle_timeout": "15s",
+    "wait_timeout": "5s",
+    "enabled": true,
+    "email_headers": []
+  }'
+
+  UPDATED_SETTINGS=$(echo "$SETTINGS_JSON" | jq -c --argjson mailpit "$MAILPIT_SMTP" '.data | .smtp = [$mailpit]')
+
+  if [ -z "$UPDATED_SETTINGS" ] || [ "$UPDATED_SETTINGS" = "null" ]; then
+    echo "Error: Failed to process settings JSON with jq."
+    return
+  fi
+
+  echo "Uploading updated SMTP settings..."
+  curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X PUT "${LISTMONK_URL}/settings" \
+    -H "Content-Type: application/json" \
+    -d "$UPDATED_SETTINGS" > /dev/null
+}
+
 # Import templates
 if [ -d "/init/templates" ]; then
   for f in /init/templates/*.html; do
@@ -201,6 +245,7 @@ if [ -d "/init/templates" ]; then
 fi
 
 # Cleanup default Listmonk resources
+configure_smtp
 delete_default_templates
 delete_default_list
 delete_test_campaigns

--- a/opendata.swiss/metadata/listmonk/init-listmonk.sh
+++ b/opendata.swiss/metadata/listmonk/init-listmonk.sh
@@ -17,8 +17,8 @@ if [ -z "$AUTH_PASS" ]; then
   MAX_RETRIES=30
   RETRY_COUNT=0
   while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    if [ -f "$DIR/install.log" ]; then
-      TOKEN=$(grep "export LISTMONK_ADMIN_API_TOKEN=" "$DIR/install.log" | cut -d'"' -f2)
+    if [ -f "$DIR/install.sh" ]; then
+      TOKEN=$(grep "export LISTMONK_ADMIN_API_TOKEN=" "$DIR/install.sh" | cut -d'"' -f2)
       if [ -n "$TOKEN" ]; then
         echo "Successfully extracted Admin API token."
         AUTH_USER="${LISTMONK_ADMIN_API_USER}"
@@ -33,7 +33,7 @@ if [ -z "$AUTH_PASS" ]; then
 fi
 
 if [ -z "$AUTH_PASS" ]; then
-  echo "Error: Token could not be extracted from install.log within timeout."
+  echo "Error: Token could not be extracted from install.sh within timeout."
   exit 1
 fi
 

--- a/opendata.swiss/metadata/listmonk/init-listmonk.sh
+++ b/opendata.swiss/metadata/listmonk/init-listmonk.sh
@@ -1,0 +1,209 @@
+#!/bin/sh
+
+# Wait for listmonk to be ready and authorized
+echo "Waiting for listmonk API to be ready and authorized..."
+
+# Use LISTMONK_ADMIN_API_USER
+if [ -z "${LISTMONK_ADMIN_API_USER}" ]; then
+  echo "Error: LISTMONK_ADMIN_API_USER is not set."
+  exit 1
+fi
+
+if [ -z "$AUTH_PASS" ]; then
+  echo "Waiting for install logs to extract token for ${LISTMONK_ADMIN_API_USER}..."
+  # Wait for the log file and the token to appear
+  MAX_RETRIES=30
+  RETRY_COUNT=0
+  while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+    if [ -f "/uploads/install.log" ]; then
+      TOKEN=$(grep "export LISTMONK_ADMIN_API_TOKEN=" /uploads/install.log | cut -d'"' -f2)
+      if [ -n "$TOKEN" ]; then
+        echo "Successfully extracted Admin API token."
+        AUTH_USER="${LISTMONK_ADMIN_API_USER}"
+        AUTH_PASS="${TOKEN}"
+        break
+      fi
+    fi
+    echo "Waiting for install log and token... ($RETRY_COUNT/$MAX_RETRIES)"
+    sleep 2
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+  done
+fi
+
+if [ -z "$AUTH_PASS" ]; then
+  echo "Error: Token could not be extracted from /uploads/install.log within timeout."
+  exit 1
+fi
+
+echo "Using Admin API credentials: ${AUTH_USER}:${TOKEN}"
+
+until curl -s -u "${AUTH_USER}:${AUTH_PASS}" http://listmonk-app:9000/api/templates > /dev/null; do
+  echo "Still waiting for API to be authorized..."
+  sleep 2
+done
+
+LISTMONK_URL="http://listmonk-app:9000/api"
+
+# Common jq filter to extract items from various Listmonk API response formats
+# 1. Direct array: [...]
+# 2. Wrapped in .data: {"data": [...]}
+# 3. Nested in .data.results: {"data": {"results": [...]}}
+JQ_EXTRACT_ITEMS='if type == "array" then .[] elif .data | type == "array" then .data[] elif .data.results | type == "array" then .data.results[] else empty end'
+
+# Function to import a template
+import_template() {
+  local file=$1
+  local name=$(basename "$file" .html)
+  echo "Importing template: $name"
+
+  content=$(cat "$file")
+
+  # Check if template already exists
+  EXISTING_ID=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/templates" | jq -r "$JQ_EXTRACT_ITEMS | select(.name == \"$name\") | .id")
+
+  if [ -z "$EXISTING_ID" ]; then
+    echo "Creating template $name..."
+    EXISTING_ID=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X POST "${LISTMONK_URL}/templates" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n --arg name "$name" --arg body "$content" '{name: $name, body: $body, type: "tx", subject: $name}')" | jq -r '.data.id // empty')
+  else
+    echo "Template $name already exists (ID: $EXISTING_ID), updating..."
+    curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X PUT "${LISTMONK_URL}/templates/$EXISTING_ID" \
+      -H "Content-Type: application/json" \
+      -d "$(jq -n --arg name "$name" --arg body "$content" '{name: $name, body: $body, type: "tx", subject: $name}')"
+  fi
+
+  # Always set the first template we find/create as the default to ensure we can delete ID=1 later
+  if [ -n "$EXISTING_ID" ] && [ "$EXISTING_ID" != "null" ]; then
+    echo "Setting template $name (ID: $EXISTING_ID) as default..."
+    curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X PUT "${LISTMONK_URL}/templates/$EXISTING_ID/default" > /dev/null
+  fi
+}
+
+# Delete default templates (except those we just imported)
+delete_default_templates() {
+  echo "Checking for default templates to remove..."
+  # Get all templates
+  TEMPLATES_JSON=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/templates")
+
+  # Default templates often have names like "Default template" or are the ones created by listmonk on install.
+  # We'll target "Default template" and any template that isn't in our local templates folder.
+
+  echo "$TEMPLATES_JSON" | jq -c "$JQ_EXTRACT_ITEMS" | while read -r template; do
+    [ -z "$template" ] && continue
+    T_NAME=$(echo "$template" | jq -r '.name // empty')
+    T_ID=$(echo "$template" | jq -r '.id // empty')
+    T_IS_DEFAULT=$(echo "$template" | jq -r '.is_default // false')
+
+    # Skip if ID or Name is empty
+    [ -z "$T_ID" ] || [ "$T_ID" = "null" ] && continue
+    [ -z "$T_NAME" ] || [ "$T_NAME" = "null" ] && continue
+
+    # Keep if it matches one of our local files
+    KEEP=false
+    if [ -d "/init/templates" ]; then
+      for f in /init/templates/*.html; do
+        [ -e "$f" ] || continue
+        L_NAME=$(basename "$f" .html)
+        if [ "$T_NAME" = "$L_NAME" ]; then
+          KEEP=true
+          break
+        fi
+      done
+    fi
+
+    # Delete if it's named "Default template" or ID=1, or any template that isn't ours and isn't marked as system default
+    if [ "$T_NAME" = "Default template" ] || [ "$T_ID" = "1" ] || [ "$KEEP" = "false" ]; then
+       echo "Deleting template: $T_NAME (ID: $T_ID)"
+       curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X DELETE "${LISTMONK_URL}/templates/$T_ID"
+    fi
+  done
+}
+
+# Delete default list
+delete_default_list() {
+  echo "Checking for default list to remove..."
+  LISTS_JSON=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/lists")
+
+  # Handle potential array response directly or within .data or nested .data.results
+  echo "$LISTS_JSON" | jq -c "$JQ_EXTRACT_ITEMS" | while read -r list; do
+    [ -z "$list" ] && continue
+    L_NAME=$(echo "$list" | jq -r '.name // empty')
+    L_ID=$(echo "$list" | jq -r '.id // empty')
+
+    # Skip if ID or Name is empty
+    [ -z "$L_ID" ] || [ "$L_ID" = "null" ] && continue
+    [ -z "$L_NAME" ] || [ "$L_NAME" = "null" ] && continue
+
+    if [ "$L_NAME" = "Default list" ] || [ "$L_ID" = "2" ]; then
+      echo "Deleting list: $L_NAME (ID: $L_ID)"
+      curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X DELETE "${LISTMONK_URL}/lists/$L_ID"
+    fi
+  done
+}
+
+# Delete test campaigns
+delete_test_campaigns() {
+  echo "Checking for test campaigns to remove..."
+  CAMPAIGNS_JSON=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/campaigns")
+
+  echo "$CAMPAIGNS_JSON" | jq -c "$JQ_EXTRACT_ITEMS" | while read -r campaign; do
+    [ -z "$campaign" ] && continue
+    C_NAME=$(echo "$campaign" | jq -r '.name // empty')
+    C_ID=$(echo "$campaign" | jq -r '.id // empty')
+    C_STATUS=$(echo "$campaign" | jq -r '.status // empty')
+
+    # Skip if ID or Name is empty
+    [ -z "$C_ID" ] || [ "$C_ID" = "null" ] && continue
+    [ -z "$C_NAME" ] || [ "$C_NAME" = "null" ] && continue
+
+    # Delete if it's named "Test campaign" or similar
+    if [ "$C_NAME" = "Test campaign" ] || [ "$C_NAME" = "My first campaign" ]; then
+      echo "Deleting campaign: $C_NAME (ID: $C_ID)"
+      curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X DELETE "${LISTMONK_URL}/campaigns/$C_ID"
+    fi
+  done
+}
+
+# Delete default subscribers (e.g. the ones added to list ID 1)
+delete_default_subscribers() {
+  echo "Checking for default subscribers to remove..."
+  # Listmonk usually doesn't have a "delete all subscribers" but we can delete subscribers from the default list
+  # or list all subscribers and delete them.
+  # First, find the ID of "Default list" if it still exists (or we just deleted it, but we might need its ID)
+
+  # Actually, Listmonk has /api/subscribers
+  SUBS_JSON=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/subscribers")
+
+  echo "$SUBS_JSON" | jq -c "$JQ_EXTRACT_ITEMS" | while read -r sub; do
+    [ -z "$sub" ] && continue
+    S_ID=$(echo "$sub" | jq -r '.id // empty')
+    S_EMAIL=$(echo "$sub" | jq -r '.email // empty')
+
+    # Skip if ID or Email is empty
+    [ -z "$S_ID" ] || [ "$S_ID" = "null" ] && continue
+    [ -z "$S_EMAIL" ] || [ "$S_EMAIL" = "null" ] && continue
+
+    # Delete if it's a known demo subscriber or if it looks like a demo one
+    if [ "$S_EMAIL" = "subscriber@example.com" ] || [ "$S_EMAIL" = "admin@listmonk.app" ] || echo "$S_EMAIL" | grep -q "@example.com"; then
+       echo "Deleting subscriber: $S_EMAIL (ID: $S_ID)"
+       curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X DELETE "${LISTMONK_URL}/subscribers/$S_ID"
+    fi
+  done
+}
+
+# Import templates
+if [ -d "/init/templates" ]; then
+  for f in /init/templates/*.html; do
+    [ -e "$f" ] || continue
+    import_template "$f"
+  done
+fi
+
+# Cleanup default Listmonk resources
+delete_default_templates
+delete_default_list
+delete_test_campaigns
+delete_default_subscribers
+
+echo "Initialization complete."

--- a/opendata.swiss/metadata/listmonk/init-listmonk.sh
+++ b/opendata.swiss/metadata/listmonk/init-listmonk.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Wait for listmonk to be ready and authorized
 echo "Waiting for listmonk API to be ready and authorized..."
 
@@ -15,8 +17,8 @@ if [ -z "$AUTH_PASS" ]; then
   MAX_RETRIES=30
   RETRY_COUNT=0
   while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    if [ -f "/uploads/install.log" ]; then
-      TOKEN=$(grep "export LISTMONK_ADMIN_API_TOKEN=" /uploads/install.log | cut -d'"' -f2)
+    if [ -f "$DIR/install.log" ]; then
+      TOKEN=$(grep "export LISTMONK_ADMIN_API_TOKEN=" "$DIR/install.log" | cut -d'"' -f2)
       if [ -n "$TOKEN" ]; then
         echo "Successfully extracted Admin API token."
         AUTH_USER="${LISTMONK_ADMIN_API_USER}"
@@ -31,7 +33,7 @@ if [ -z "$AUTH_PASS" ]; then
 fi
 
 if [ -z "$AUTH_PASS" ]; then
-  echo "Error: Token could not be extracted from /uploads/install.log within timeout."
+  echo "Error: Token could not be extracted from install.log within timeout."
   exit 1
 fi
 

--- a/opendata.swiss/metadata/listmonk/init-listmonk.sh
+++ b/opendata.swiss/metadata/listmonk/init-listmonk.sh
@@ -167,33 +167,6 @@ delete_test_campaigns() {
   done
 }
 
-# Delete default subscribers (e.g. the ones added to list ID 1)
-delete_default_subscribers() {
-  echo "Checking for default subscribers to remove..."
-  # Listmonk usually doesn't have a "delete all subscribers" but we can delete subscribers from the default list
-  # or list all subscribers and delete them.
-  # First, find the ID of "Default list" if it still exists (or we just deleted it, but we might need its ID)
-
-  # Actually, Listmonk has /api/subscribers
-  SUBS_JSON=$(curl -s -u "${AUTH_USER}:${AUTH_PASS}" "${LISTMONK_URL}/subscribers")
-
-  echo "$SUBS_JSON" | jq -c "$JQ_EXTRACT_ITEMS" | while read -r sub; do
-    [ -z "$sub" ] && continue
-    S_ID=$(echo "$sub" | jq -r '.id // empty')
-    S_EMAIL=$(echo "$sub" | jq -r '.email // empty')
-
-    # Skip if ID or Email is empty
-    [ -z "$S_ID" ] || [ "$S_ID" = "null" ] && continue
-    [ -z "$S_EMAIL" ] || [ "$S_EMAIL" = "null" ] && continue
-
-    # Delete if it's a known demo subscriber or if it looks like a demo one
-    if [ "$S_EMAIL" = "subscriber@example.com" ] || [ "$S_EMAIL" = "admin@listmonk.app" ] || echo "$S_EMAIL" | grep -q "@example.com"; then
-       echo "Deleting subscriber: $S_EMAIL (ID: $S_ID)"
-       curl -s -u "${AUTH_USER}:${AUTH_PASS}" -X DELETE "${LISTMONK_URL}/subscribers/$S_ID"
-    fi
-  done
-}
-
 # Function to configure SMTP
 configure_smtp() {
   echo "Configuring SMTP to use Mailpit..."
@@ -251,6 +224,5 @@ configure_smtp
 delete_default_templates
 delete_default_list
 delete_test_campaigns
-delete_default_subscribers
 
 echo "Initialization complete."

--- a/opendata.swiss/metadata/listmonk/templates/deutsch.html
+++ b/opendata.swiss/metadata/listmonk/templates/deutsch.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Default Template</title>
+</head>
+<body>
+<h1>Hello, {{.Subscriber.FirstName}}</h1>
+<div>
+    <a href="{{ .Tx.Data.link }}">{{ .Tx.Data.name }}</a>
+</div>
+<p>Unsubscribe: here</p>
+</body>
+</html>

--- a/opendata.swiss/ui/README.md
+++ b/opendata.swiss/ui/README.md
@@ -167,3 +167,18 @@ The Netlify credentials are [here](https://passbolt.zazuko.com/app/passwords/vie
 In the single Netlify Project, the OAuth App is set up using Client ID and secret. Most importantly, each instance of ODS
 must be added in the [Domain Management](https://app.netlify.com/projects/preeminent-flan-064546/domain-management)
 section.
+
+### Subscriptions
+
+Subscriptions are managed by [Listmonk](https://listmonk.app) and in the dev environment,
+[mailpit](http://localhost:8025) is used to catch all sent emails.
+
+For this configuration to work, make sure to run the [docker compose stack](../metadata/docker-compose.yaml) first.
+Then, set the following environment variables before running the dev instance:
+
+```dotenv
+NUXT_LISTMONK_API_USER=
+NUXT_LISTMONK_API_TOKEN=
+```
+
+Their values can be retrieved from [install.log](../metadata/listmonk/install.log) produced by listmonk installation script.

--- a/opendata.swiss/ui/README.md
+++ b/opendata.swiss/ui/README.md
@@ -177,8 +177,10 @@ For this configuration to work, make sure to run the [docker compose stack](../m
 Then, set the following environment variables before running the dev instance:
 
 ```dotenv
-NUXT_LISTMONK_API_USER=
+NUXT_LISTMONK_API_URL=http://localhost:9000/
+NUXT_LISTMONK_API_USER=admin-api
 NUXT_LISTMONK_API_TOKEN=
 ```
 
-Their values can be retrieved from [install.log](../metadata/listmonk/install.log) produced by listmonk installation script.
+The username can be changed [docker-compose.yaml](../metadata/docker-compose.yaml).
+The token can be retrieved from [install.log](../metadata/listmonk/install.log) produced by listmonk installation script.

--- a/opendata.swiss/ui/README.md
+++ b/opendata.swiss/ui/README.md
@@ -183,4 +183,4 @@ NUXT_LISTMONK_API_TOKEN=
 ```
 
 The username can be changed [docker-compose.yaml](../metadata/docker-compose.yaml).
-The token can be retrieved from [install.log](../metadata/listmonk/install.log) produced by listmonk installation script.
+The token can be retrieved from [install.sh](../metadata/listmonk/install.sh) produced by listmonk installation script.

--- a/opendata.swiss/ui/nuxt.config.ts
+++ b/opendata.swiss/ui/nuxt.config.ts
@@ -65,6 +65,13 @@ export default defineNuxtConfig({
       },
     },
     apiTunerTests: false,
+    listmonk: {
+      api: {
+        url: '',
+        user: '',
+        token: '',
+      },
+    },
   },
   dir: {
     pages: resolve(import.meta.dirname, 'pages'),
@@ -73,6 +80,8 @@ export default defineNuxtConfig({
     transpile: ['form-data'],
   },
   routeRules: {
+    '/api/showcases': { basicAuth: true },
+    '/api/subscribe/*': { basicAuth: true },
     '*/showcases/submit': { ssr: false },
   },
   compatibilityDate: '2025-07-15',
@@ -84,6 +93,9 @@ export default defineNuxtConfig({
       '~~/server/plugins/zod-locale',
       '~~/server/plugins/showcase-harvesting-trigger',
     ],
+    hooks: {
+      'dev:reload': () => import('sharp'),
+    },
   },
   cmsAssets: {
     contentPath: resolve(import.meta.dirname, 'content/assets'),

--- a/opendata.swiss/ui/nuxt.config.ts
+++ b/opendata.swiss/ui/nuxt.config.ts
@@ -69,7 +69,7 @@ export default defineNuxtConfig({
       api: {
         url: '',
         user: '',
-        token: '',
+        token: process.env.LISTMONK_ADMIN_API_TOKEN,
       },
     },
   },

--- a/opendata.swiss/ui/package.json
+++ b/opendata.swiss/ui/package.json
@@ -8,7 +8,7 @@
     "decap": "rimraf public/admin && (cd ../..; PORT=8088 decap-server) & dotenv -- vite src/admin",
     "predev": "shx test -d content || git clone git@github.com:opendata-swiss/opendata-swiss-cms-content-test.git content",
     "dev": "HOST=0.0.0.0 nuxt dev",
-    "api-tuner": "npx api-tuner@0.6 --base-iri http://localhost:3000",
+    "api-tuner": "sh ../metadata/listmonk/install.sh; npx api-tuner@0.6.1 --base-iri http://localhost:3000",
     "lint": "eslint --quiet",
     "test": "npm run api-tuner -- server/tests/*.n3",
     "prebuild": "vite build src/admin --emptyOutDir",

--- a/opendata.swiss/ui/package.json
+++ b/opendata.swiss/ui/package.json
@@ -8,7 +8,7 @@
     "decap": "rimraf public/admin && (cd ../..; PORT=8088 decap-server) & dotenv -- vite src/admin",
     "predev": "shx test -d content || git clone git@github.com:opendata-swiss/opendata-swiss-cms-content-test.git content",
     "dev": "HOST=0.0.0.0 nuxt dev",
-    "api-tuner": "npx api-tuner@0.5.2 --base-iri http://localhost:3000",
+    "api-tuner": "npx api-tuner@0.6 --base-iri http://localhost:3000",
     "lint": "eslint --quiet",
     "test": "npm run api-tuner -- server/tests/*.n3",
     "prebuild": "vite build src/admin --emptyOutDir",

--- a/opendata.swiss/ui/server/api/subscribe/category.post.ts
+++ b/opendata.swiss/ui/server/api/subscribe/category.post.ts
@@ -1,0 +1,3 @@
+import { subscribe } from './subscribe'
+
+export default defineEventHandler(subscribe('categories', 'category'))

--- a/opendata.swiss/ui/server/api/subscribe/dataset.post.ts
+++ b/opendata.swiss/ui/server/api/subscribe/dataset.post.ts
@@ -1,0 +1,3 @@
+import { subscribe } from './subscribe'
+
+export default defineEventHandler(subscribe('datasets', 'dataset'))

--- a/opendata.swiss/ui/server/api/subscribe/listmonk.types.ts
+++ b/opendata.swiss/ui/server/api/subscribe/listmonk.types.ts
@@ -1,0 +1,21 @@
+export interface Envelope<T> {
+  data: T
+}
+
+interface Attribs extends Record<string, unknown> {
+  datasets?: string[]
+  categories?: string[]
+  organisations?: string[]
+}
+
+export interface Subscriber {
+  id: number
+  name: string
+  status: 'enabled' | 'blocklisted'
+  lists?: number[]
+  attribs?: Attribs
+}
+
+export interface Subscribers {
+  results: Array<Subscriber>
+}

--- a/opendata.swiss/ui/server/api/subscribe/organisation.post.ts
+++ b/opendata.swiss/ui/server/api/subscribe/organisation.post.ts
@@ -1,0 +1,3 @@
+import { subscribe } from './subscribe'
+
+export default defineEventHandler(subscribe('organisations', 'organisation'))

--- a/opendata.swiss/ui/server/api/subscribe/subscribe.ts
+++ b/opendata.swiss/ui/server/api/subscribe/subscribe.ts
@@ -1,0 +1,70 @@
+import type { H3Event } from 'h3'
+import type * as Linkmonk from './listmonk.types'
+import { getLanguage } from '#server/lib/locale'
+
+export function subscribe(key: 'categories' | 'datasets' | 'organisations', queryParam: 'category' | 'organisation' | 'dataset') {
+  return async (event: H3Event) => {
+    const { user: { email } } = event.context
+    const query = getQuery(event)
+    const values = Array.isArray(query[queryParam]) ? query[queryParam] : [query[queryParam]]
+    const language = getLanguage(event)
+
+    const { listmonk: { api: listmonk } } = useRuntimeConfig()
+
+    const authorization = {
+      Authorization: `token ${listmonk.user}:${listmonk.token}`,
+    }
+
+    const getSubscribers = await fetch(`${listmonk.url}api/subscribers?query=subscribers.email = '${email}'`, {
+      headers: authorization,
+    })
+
+    if (!getSubscribers.ok) {
+      throw new Error(`Failed to fetch subscribers: ${getSubscribers.status} ${getSubscribers.statusText}`)
+    }
+
+    const subscribers: Linkmonk.Envelope<Linkmonk.Subscribers> = await getSubscribers.json()
+
+    const subscriber = subscribers.data.results.pop() || {
+      name: '',
+      status: 'enabled',
+      lists: [],
+      attribs: {
+        language,
+        [key]: values,
+      },
+    }
+
+    if ('id' in subscriber) {
+      await fetch(`${listmonk.url}api/subscribers/${subscriber.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({
+          attribs: {
+            [key]: [...new Set([
+              ...(subscriber.attribs?.[key] || []),
+              ...values,
+            ])],
+          },
+        }),
+        headers: {
+          ...authorization,
+          'content-type': 'application/json',
+        },
+      })
+    }
+    else {
+      await fetch(`${listmonk.url}api/subscribers`, {
+        method: 'POST',
+        body: JSON.stringify(subscriber),
+        headers: {
+          ...authorization,
+          'content-type': 'application/json',
+        },
+      })
+    }
+
+    return {
+      message: 'Subscription successful',
+    }
+  }
+}

--- a/opendata.swiss/ui/server/lib/locale.ts
+++ b/opendata.swiss/ui/server/lib/locale.ts
@@ -1,0 +1,9 @@
+import type { H3Event } from 'h3'
+
+import acceptLanguage from 'accept-language'
+
+acceptLanguage.languages(['de', 'fr', 'it', 'en'])
+
+export function getLanguage({ headers }: H3Event): string {
+  return acceptLanguage.get(headers.get('accept-language')) || 'de'
+}

--- a/opendata.swiss/ui/server/middleware/basic-auth.ts
+++ b/opendata.swiss/ui/server/middleware/basic-auth.ts
@@ -1,10 +1,17 @@
 const BASIC_AUTH_USERNAME = 'api-tuner'
 const BASIC_AUTH_PASSWORD = 'e2e-tests'
 
+declare module 'nitropack/types' {
+  interface NitroRouteRules {
+    basicAuth?: boolean
+  }
+}
+
 export default defineEventHandler(async (event) => {
   const { apiTunerTests } = useRuntimeConfig()
 
-  if (!(event.path === '/api/showcases' && event.method === 'POST')) {
+  const routeRules = getRouteRules(event)
+  if (!routeRules.basicAuth || !isMethod(event, 'POST')) {
     return
   }
 
@@ -18,6 +25,7 @@ export default defineEventHandler(async (event) => {
     if (username === BASIC_AUTH_USERNAME && password === BASIC_AUTH_PASSWORD) {
       user = {
         name: username,
+        email: 'john@example.com',
       }
     }
     else {

--- a/opendata.swiss/ui/server/plugins/zod-locale.ts
+++ b/opendata.swiss/ui/server/plugins/zod-locale.ts
@@ -1,15 +1,13 @@
 import { defineNitroPlugin } from '#imports'
 import { config } from 'zod'
 import { en, de, fr, it } from 'zod/locales'
-import acceptLanguage from 'accept-language'
-
-acceptLanguage.languages(['de', 'fr', 'it', 'en'])
+import { getLanguage } from '#server/lib/locale'
 
 const languages = new Map(Object.entries({ en, de, fr, it }))
 
 export default defineNitroPlugin((nitro) => {
-  nitro.hooks.hook('request', ({ headers }) => {
-    const language = acceptLanguage.get(headers.get('accept-language'))
+  nitro.hooks.hook('request', (event) => {
+    const language = getLanguage(event)
     const locale = languages.get(language || 'de') || de
     config(locale())
   })

--- a/opendata.swiss/ui/server/tests/subscribe/category.post.n3
+++ b/opendata.swiss/ui/server/tests/subscribe/category.post.n3
@@ -1,0 +1,35 @@
+PREFIX tuner: <https://api-tuner.described.at/>
+PREFIX string: <http://www.w3.org/2000/10/swap/string#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX tuner: <https://api-tuner.described.at/>
+PREFIX earl: <http://www.w3.org/ns/earl#>
+
+<#subscribeToCategory>
+  a earl:TestCase ;
+  rdfs:label "Subscribe to category" ;
+  <#requestToSubmit> [
+    a tuner:Request ;
+      tuner:url </api/subscribe/category> ;
+      tuner:method "POST" ;
+      tuner:header ( "Authorization" "Basic YXBpLXR1bmVyOmUyZS10ZXN0cw==" ) ;
+      tuner:query ( "category" "INTR" ) ;
+  ] ;
+  <#requestToVerify> [
+    a tuner:Request ;
+      tuner:url <http://localhost:9000/api/subscribers/1> ;
+      tuner:method "GET" ;
+      tuner:header ( "Authorization" "token admin-api:zRCx7erWy7ONGels6D8efSiP5s1yB4hi" ) ;
+  ] ;
+  tuner:formula {
+    <#subscribeToCategory> <#requestToSubmit> ?req .
+    ?req tuner:response ?submitted .
+    ?submitted tuner:http_code 200 .
+
+    <#subscribeToCategory> <#requestToVerify> ?req1 .
+    ?req1 tuner:response ?verified .
+
+    ?verified tuner:http_code 200 .
+    ?verified tuner:body ?subscriber .
+    ?verified tuner:jsonPath ( "$.data.attribs.categories" "INTR" string:contains ).
+  } ;
+.

--- a/opendata.swiss/ui/server/tests/subscribe/category.post.n3
+++ b/opendata.swiss/ui/server/tests/subscribe/category.post.n3
@@ -18,7 +18,7 @@ PREFIX earl: <http://www.w3.org/ns/earl#>
     a tuner:Request ;
       tuner:url <http://localhost:9000/api/subscribers/1> ;
       tuner:method "GET" ;
-      tuner:header ( "Authorization" "token admin-api:zRCx7erWy7ONGels6D8efSiP5s1yB4hi" ) ;
+      tuner:header ( "Authorization" "token admin-api:$LISTMONK_ADMIN_API_TOKEN" ) ;
   ] ;
   tuner:formula {
     <#subscribeToCategory> <#requestToSubmit> ?req .

--- a/opendata.swiss/ui/server/tests/subscribe/dataset.post.n3
+++ b/opendata.swiss/ui/server/tests/subscribe/dataset.post.n3
@@ -18,7 +18,7 @@ PREFIX earl: <http://www.w3.org/ns/earl#>
     a tuner:Request ;
       tuner:url <http://localhost:9000/api/subscribers/1> ;
       tuner:method "GET" ;
-      tuner:header ( "Authorization" "token admin-api:zRCx7erWy7ONGels6D8efSiP5s1yB4hi" ) ;
+      tuner:header ( "Authorization" "token admin-api:$LISTMONK_ADMIN_API_TOKEN" ) ;
   ] ;
   tuner:formula {
     <#subscribeToDataset> <#requestToSubmit> ?req .

--- a/opendata.swiss/ui/server/tests/subscribe/dataset.post.n3
+++ b/opendata.swiss/ui/server/tests/subscribe/dataset.post.n3
@@ -1,0 +1,35 @@
+PREFIX tuner: <https://api-tuner.described.at/>
+PREFIX string: <http://www.w3.org/2000/10/swap/string#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX tuner: <https://api-tuner.described.at/>
+PREFIX earl: <http://www.w3.org/ns/earl#>
+
+<#subscribeToDataset>
+  a earl:TestCase ;
+  rdfs:label "Subscribe to dataset" ;
+  <#requestToSubmit> [
+    a tuner:Request ;
+      tuner:url </api/subscribe/dataset> ;
+      tuner:method "POST" ;
+      tuner:header ( "Authorization" "Basic YXBpLXR1bmVyOmUyZS10ZXN0cw==" ) ;
+      tuner:query ( "dataset" "dataset1" ) ;
+  ] ;
+  <#requestToVerify> [
+    a tuner:Request ;
+      tuner:url <http://localhost:9000/api/subscribers/1> ;
+      tuner:method "GET" ;
+      tuner:header ( "Authorization" "token admin-api:zRCx7erWy7ONGels6D8efSiP5s1yB4hi" ) ;
+  ] ;
+  tuner:formula {
+    <#subscribeToDataset> <#requestToSubmit> ?req .
+    ?req tuner:response ?submitted .
+    ?submitted tuner:http_code 200 .
+
+    <#subscribeToDataset> <#requestToVerify> ?req1 .
+    ?req1 tuner:response ?verified .
+
+    ?verified tuner:http_code 200 .
+    ?verified tuner:body ?subscriber .
+    ?verified tuner:jsonPath ( "$.data.attribs.datasets" "dataset1" string:contains ).
+  } ;
+.

--- a/opendata.swiss/ui/server/tests/subscribe/organisation.post.n3
+++ b/opendata.swiss/ui/server/tests/subscribe/organisation.post.n3
@@ -1,0 +1,35 @@
+PREFIX tuner: <https://api-tuner.described.at/>
+PREFIX string: <http://www.w3.org/2000/10/swap/string#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX tuner: <https://api-tuner.described.at/>
+PREFIX earl: <http://www.w3.org/ns/earl#>
+
+<#subscribeToOrganisation>
+  a earl:TestCase ;
+  rdfs:label "Subscribe to organisation" ;
+  <#requestToSubmit> [
+    a tuner:Request ;
+      tuner:url </api/subscribe/organisation> ;
+      tuner:method "POST" ;
+      tuner:header ( "Authorization" "Basic YXBpLXR1bmVyOmUyZS10ZXN0cw==" ) ;
+      tuner:query ( "organisation" "BAFU" ) ;
+  ] ;
+  <#requestToVerify> [
+    a tuner:Request ;
+      tuner:url <http://localhost:9000/api/subscribers/1> ;
+      tuner:method "GET" ;
+      tuner:header ( "Authorization" "token admin-api:zRCx7erWy7ONGels6D8efSiP5s1yB4hi" ) ;
+  ] ;
+  tuner:formula {
+    <#subscribeToOrganisation> <#requestToSubmit> ?req .
+    ?req tuner:response ?submitted .
+    ?submitted tuner:http_code 200 .
+
+    <#subscribeToOrganisation> <#requestToVerify> ?req1 .
+    ?req1 tuner:response ?verified .
+
+    ?verified tuner:http_code 200 .
+    ?verified tuner:body ?subscriber .
+    ?verified tuner:jsonPath ( "$.data.attribs.organisations" "BAFU" string:contains ).
+  } ;
+.

--- a/opendata.swiss/ui/server/tests/subscribe/organisation.post.n3
+++ b/opendata.swiss/ui/server/tests/subscribe/organisation.post.n3
@@ -18,7 +18,7 @@ PREFIX earl: <http://www.w3.org/ns/earl#>
     a tuner:Request ;
       tuner:url <http://localhost:9000/api/subscribers/1> ;
       tuner:method "GET" ;
-      tuner:header ( "Authorization" "token admin-api:zRCx7erWy7ONGels6D8efSiP5s1yB4hi" ) ;
+      tuner:header ( "Authorization" "token admin-api:$LISTMONK_ADMIN_API_TOKEN" ) ;
   ] ;
   tuner:formula {
     <#subscribeToOrganisation> <#requestToSubmit> ?req .


### PR DESCRIPTION
This a first PR for the feature to subscriptions.

In this PR, I added [listmonk](https://listmonk.app) and [mailpit](https://mailpit.axllent.org/) to the local stack. The former manages dataset subscription for users and will send out digest on schedule (maybe k8s, maybe GitHub workflow - not a built-in feature). The latter is a local smtp "server" which does not actually send anything but when used by Listmonk, lets devs see what emails it received.

In out app, I added APIs methods to create subscription profiles for users. 

In a next PRs, I will add
- the necessary functionality to the app itself so that users can subscribe from the UI
- a page where they can unsubscribe from select criteria or unsubscribe completely + a link in the emails
- actual sending the email using Listmonk's API

More comments inline