### PR TITLE
newer hub-repo version fixes organization API issue

### DIFF
--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   piveau-hub-repo:
-    image: piveau/hub-repo:3.5.0
+    image: piveau/hub-repo:3.5.2
     restart: unless-stopped
     logging:
       options:
@@ -28,7 +28,7 @@ services:
       - ./piveau_profile:/piv-profile:ro
 
   piveau-hub-search:
-    image: registry.gitlab.com/piveau/hub/piveau-hub-search:5.3.1
+    image: registry.gitlab.com/piveau/hub/piveau-hub-search:5.3.4
     restart: unless-stopped
     logging:
       options:

--- a/opendata.swiss/metadata/piveau_systemtests/docker-compose.yaml
+++ b/opendata.swiss/metadata/piveau_systemtests/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   # docker-compose-hub.yml #
   ##########################
   piveau-hub-repo:
-    image: piveau/hub-repo:3.5.1
+    image: piveau/hub-repo:3.5.2
 
     restart: unless-stopped
     logging:


### PR DESCRIPTION
`hub-repo:3.5.0` has known issue in the organization API

`hub-repo:3.5.1` or newer is needed to have that resolved