### PR TITLE
Preferences message

### DIFF
--- a/opendata.swiss/ui/app/app.vue
+++ b/opendata.swiss/ui/app/app.vue
@@ -34,6 +34,22 @@
               />
             </template>
           </OdsNotificationBanner>
+          <OdsNotificationBanner
+            v-if="errorMessage"
+            type="error"
+          >
+            {{ t(`message.${errorMessage}`) }}
+
+            <template #buttons>
+              <OdsButton
+                variant="outline"
+                title="Close"
+                icon-right
+                icon="Checkmark"
+                @click="closeErrorMessages()"
+              />
+            </template>
+          </OdsNotificationBanner>
           <NuxtPage :page-key="route => route.path" />
         </div>
       </Transition>
@@ -135,8 +151,15 @@ function handleResize() {
 const messageCookie = useCookie('message')
 const message = computed(() => messageCookie.value)
 
+const errorMessageCookie = useCookie('message.error')
+const errorMessage = computed(() => errorMessageCookie.value)
+
 function closeMessages() {
   messageCookie.value = undefined
+}
+
+function closeErrorMessages() {
+  errorMessageCookie.value = undefined
 }
 
 onMounted(() => {

--- a/opendata.swiss/ui/app/components/OdsDropdownMenu.vue
+++ b/opendata.swiss/ui/app/components/OdsDropdownMenu.vue
@@ -103,14 +103,14 @@ onBeforeUnmount(() => {
         <div v-else />
         <OdsButton
           icon="Cancel"
-          title="close menu"
+          :title="t('message.button.close')"
           variant="bare"
           size="sm"
           icon-right
           class="ods-close"
           @click="isOpen = false"
         >
-          <span class="ods-close">{{ t('message.header.navigation.close') }}</span>
+          <span class="ods-close">{{ t('message.button.close') }}</span>
         </OdsButton>
       </div>
       <Transition

--- a/opendata.swiss/ui/i18n/locales/de.json
+++ b/opendata.swiss/ui/i18n/locales/de.json
@@ -84,6 +84,7 @@
       "to_publisher": "Zum Herausgeber",
       "success": "Abonnement erfolgreich",
       "preferences": {
+        "page_title": "Abonnement-Einstellungen",
         "title": "Passen Sie Ihre Abonnement-Einstellungen an",
         "legend": "Wie oft möchten Sie Updates erhalten?",
         "frequency": {

--- a/opendata.swiss/ui/i18n/locales/de.json
+++ b/opendata.swiss/ui/i18n/locales/de.json
@@ -29,6 +29,9 @@
         }
       }
     },
+    "button": {
+      "close": "Schliessen"
+    },
     "ods_toc": {
       "contents": "Inhaltverzeichnis"
     },
@@ -79,7 +82,22 @@
       "to_dataset": "Zum Dataset",
       "to_category": "Zur Kategorie",
       "to_publisher": "Zum Herausgeber",
-      "success": "Abonnement erfolgreich"
+      "success": "Abonnement erfolgreich",
+      "preferences": {
+        "title": "Passen Sie Ihre Abonnement-Einstellungen an",
+        "legend": "Wie oft möchten Sie Updates erhalten?",
+        "frequency": {
+          "daily": "Täglich",
+          "weekly": "Wöchentlich"
+        },
+        "datasets_label": "Für Updates ausgewählte Datensätze",
+        "categories_label": "Für Updates ausgewählte Kategorien",
+        "update_button": "Einstellungen aktualisieren",
+        "unsubscribe_title": "Oder vollständig abmelden",
+        "unsubscribe_button": "Von allen E-Mails abmelden",
+        "updated": "Einstellungen erfolgreich aktualisiert",
+        "update_failed": "Aktualisieren der Einstellungen fehlgeschlagen. Bitte versuchen Sie es später erneut."
+      }
     },
     "showcase": {
       "type": {

--- a/opendata.swiss/ui/i18n/locales/en.json
+++ b/opendata.swiss/ui/i18n/locales/en.json
@@ -83,6 +83,7 @@
       "to_publisher": "To publisher",
       "success": "Subscription successful",
       "preferences": {
+        "page_title": "Subscription preferences",
         "title": "Fine-tune you subscription preferences",
         "legend": "How often do you want to receive updates?",
         "frequency": {

--- a/opendata.swiss/ui/i18n/locales/en.json
+++ b/opendata.swiss/ui/i18n/locales/en.json
@@ -18,7 +18,6 @@
         "handbook": "Handbook",
         "search": "Search",
         "showcases": "Showcases",
-        "close": "Close",
         "more": "More...",
         "showcase_submit": "Submit a showcase",
         "admin": {
@@ -28,6 +27,9 @@
           "categories": "DCAT Categories"
         }
       }
+    },
+    "button": {
+      "close": "Close"
     },
     "ods_toc": {
       "contents": "Table of contents"
@@ -79,7 +81,22 @@
       "to_dataset": "To dataset",
       "to_category": "To category",
       "to_publisher": "To publisher",
-      "success": "Subscription successful"
+      "success": "Subscription successful",
+      "preferences": {
+        "title": "Fine-tune you subscription preferences",
+        "legend": "How often do you want to receive updates?",
+        "frequency": {
+          "daily": "Daily",
+          "weekly": "Weekly"
+        },
+        "datasets_label": "Datasets selected for updates",
+        "categories_label": "Categories selected for updates",
+        "update_button": "Update your preferences",
+        "unsubscribe_title": "Or unsubscribe completely",
+        "unsubscribe_button": "Unsubscribe from all emails",
+        "updated": "Preferences updated successfully",
+        "update_failed": "Failed to update preferences. Please try again later."
+      }
     },
     "showcase": {
       "type": {

--- a/opendata.swiss/ui/i18n/locales/fr.json
+++ b/opendata.swiss/ui/i18n/locales/fr.json
@@ -29,6 +29,9 @@
         }
       }
     },
+    "button": {
+      "close": "Fermer"
+    },
     "ods_toc": {
       "contents": "Table des matières"
     },
@@ -79,7 +82,22 @@
       "to_dataset": "Vers le jeu de données",
       "to_category": "Vers la catégorie",
       "to_publisher": "Vers l'éditeur",
-      "success": "Abonnement réussi"
+      "success": "Abonnement réussi",
+      "preferences": {
+        "title": "Affinez vos préférences d’abonnement",
+        "legend": "À quelle fréquence souhaitez-vous recevoir des mises à jour ?",
+        "frequency": {
+          "daily": "Quotidien",
+          "weekly": "Hebdomadaire"
+        },
+        "datasets_label": "Jeux de données sélectionnés pour les mises à jour",
+        "categories_label": "Catégories sélectionnées pour les mises à jour",
+        "update_button": "Mettre à jour vos préférences",
+        "unsubscribe_title": "Ou vous désabonner complètement",
+        "unsubscribe_button": "Se désabonner de tous les e-mails",
+        "updated": "Préférences mises à jour avec succès",
+        "update_failed": "Échec de la mise à jour des préférences. Veuillez réessayer plus tard."
+      }
     },
     "showcase": {
       "type": {

--- a/opendata.swiss/ui/i18n/locales/fr.json
+++ b/opendata.swiss/ui/i18n/locales/fr.json
@@ -84,6 +84,7 @@
       "to_publisher": "Vers l'éditeur",
       "success": "Abonnement réussi",
       "preferences": {
+        "page_title": "Préférences d’abonnement",
         "title": "Affinez vos préférences d’abonnement",
         "legend": "À quelle fréquence souhaitez-vous recevoir des mises à jour ?",
         "frequency": {

--- a/opendata.swiss/ui/i18n/locales/it.json
+++ b/opendata.swiss/ui/i18n/locales/it.json
@@ -84,6 +84,7 @@
       "to_publisher": "All'editore",
       "success": "Iscrizione riuscita",
       "preferences": {
+        "page_title": "Preferenze di abbonamento",
         "title": "Affina le preferenze di abbonamento",
         "legend": "Con quale frequenza desideri ricevere gli aggiornamenti?",
         "frequency": {

--- a/opendata.swiss/ui/i18n/locales/it.json
+++ b/opendata.swiss/ui/i18n/locales/it.json
@@ -84,8 +84,8 @@
       "to_publisher": "All'editore",
       "success": "Iscrizione riuscita",
       "preferences": {
-        "page_title": "Preferenze di abbonamento",
-        "title": "Affina le preferenze di abbonamento",
+        "page_title": "Preferenze di iscrizione",
+        "title": "Affina le preferenze di iscrizione",
         "legend": "Con quale frequenza desideri ricevere gli aggiornamenti?",
         "frequency": {
           "daily": "Giornaliero",

--- a/opendata.swiss/ui/i18n/locales/it.json
+++ b/opendata.swiss/ui/i18n/locales/it.json
@@ -29,6 +29,9 @@
         }
       }
     },
+    "button": {
+      "close": "Chiudi"
+    },
     "ods_toc": {
       "contents": "Contenuti"
     },
@@ -79,7 +82,22 @@
       "to_dataset": "Al set di dati",
       "to_category": "Alla categoria",
       "to_publisher": "All'editore",
-      "success": "Iscrizione riuscita"
+      "success": "Iscrizione riuscita",
+      "preferences": {
+        "title": "Affina le preferenze di abbonamento",
+        "legend": "Con quale frequenza desideri ricevere gli aggiornamenti?",
+        "frequency": {
+          "daily": "Giornaliero",
+          "weekly": "Settimanale"
+        },
+        "datasets_label": "Set di dati selezionati per gli aggiornamenti",
+        "categories_label": "Categorie selezionate per gli aggiornamenti",
+        "update_button": "Aggiorna le preferenze",
+        "unsubscribe_title": "Oppure annulla l’iscrizione completamente",
+        "unsubscribe_button": "Annulla l’iscrizione da tutte le e-mail",
+        "updated": "Preferenze aggiornate correttamente",
+        "update_failed": "Aggiornamento delle preferenze non riuscito. Riprova più tardi."
+      }
     },
     "showcase": {
       "type": {

--- a/opendata.swiss/ui/pages/subscription/preferences.vue
+++ b/opendata.swiss/ui/pages/subscription/preferences.vue
@@ -93,6 +93,7 @@ import OdsButton from '../../app/components/OdsButton.vue'
 import { useVocabularySearch } from '../../app/piveau/vocabularies'
 
 const route = useRoute()
+const router = useRouter()
 
 const form = ref<HTMLFormElement>()
 const datasets = ref([])
@@ -104,6 +105,10 @@ const query = {
   token: route.query.token,
 }
 const { data } = await useFetch('/api/subscription/preferences', { query })
+if (!data.value) {
+  router.replace('/404')
+}
+
 const preferences = data.value.preferences
 
 const { useResource } = useDatasetsSearch()
@@ -136,6 +141,8 @@ const datasetsLoaded = preferences.datasets.map(async (id) => {
 
 datasets.value = (await Promise.all(datasetsLoaded)).sort((a, b) => a.name.localeCompare(b.name))
 
+const message = useCookie('message')
+
 async function updatePreferences() {
   const { data, error } = await useFetch('/api/subscription/preferences', {
     query,
@@ -147,7 +154,7 @@ async function updatePreferences() {
   })
 
   if (error) {
-    alert('Preferences updated successfully')
+    message.value = 'Preferences updated successfully'
   }
   else {
     console.error(data)

--- a/opendata.swiss/ui/pages/subscription/preferences.vue
+++ b/opendata.swiss/ui/pages/subscription/preferences.vue
@@ -8,30 +8,30 @@
       >
         <div class="container gap--responsive">
           <h2 class="h2">
-            Fine-tune you subscription preferences
+            {{ t('message.subscribe.preferences.title') }}
           </h2>
           <section>
             <form ref="form">
-              <OdsRadioGroup legend="How often do you want to receive updates?">
+              <OdsRadioGroup :legend="t('message.subscribe.preferences.legend')">
                 <OdsRadio
                   id="daily"
                   name="frequency"
                   value="daily"
-                  label="Daily"
+                  :label="t('message.subscribe.preferences.frequency.daily')"
                   :checked="frequency === 'daily'"
                 />
                 <OdsRadio
                   id="weekly"
                   name="frequency"
                   value="weekly"
-                  label="Weekly"
+                  :label="t('message.subscribe.preferences.frequency.weekly')"
                   :checked="frequency === 'weekly'"
                 />
               </OdsRadioGroup>
 
               <OdsFormField
                 v-if="datasets.length > 0"
-                label="Datasets selected for updates"
+                :label="t('message.subscribe.preferences.datasets_label')"
                 for="dataset"
               >
                 <OdsCheckbox
@@ -46,7 +46,7 @@
 
               <OdsFormField
                 v-if="categories.length > 0"
-                label="Categories selected for updates"
+                :label="t('message.subscribe.preferences.categories_label')"
                 for="dataset"
               >
                 <OdsCheckbox
@@ -59,7 +59,7 @@
                 />
               </OdsFormField>
               <OdsButton
-                title="Update your preferences"
+                :title="t('message.subscribe.preferences.update_button')"
                 variant="outline"
                 @click="updatePreferences"
               />
@@ -67,10 +67,10 @@
           </section>
           <section>
             <h2 class="h2">
-              Or unsubscribe completely
+              {{ t('message.subscribe.preferences.unsubscribe_title') }}
             </h2>
             <OdsButton
-              title="Unsubscribe from all emails"
+              :title="t('message.subscribe.preferences.unsubscribe_button')"
               variant="outline"
             />
           </section>
@@ -91,6 +91,7 @@ import { useRoute } from 'vue-router'
 import { useDatasetsSearch } from '../../app/piveau/datasets.js'
 import OdsButton from '../../app/components/OdsButton.vue'
 import { useVocabularySearch } from '../../app/piveau/vocabularies'
+import { useI18n } from '#imports'
 
 const route = useRoute()
 const router = useRouter()
@@ -99,6 +100,7 @@ const form = ref<HTMLFormElement>()
 const datasets = ref([])
 const categories = ref([])
 const frequency = ref()
+const { t } = useI18n()
 
 const query = {
   id: route.query.id,
@@ -142,6 +144,7 @@ const datasetsLoaded = preferences.datasets.map(async (id) => {
 datasets.value = (await Promise.all(datasetsLoaded)).sort((a, b) => a.name.localeCompare(b.name))
 
 const message = useCookie('message')
+const errorMessage = useCookie('message-error')
 
 async function updatePreferences() {
   const { data, error } = await useFetch('/api/subscription/preferences', {
@@ -154,11 +157,11 @@ async function updatePreferences() {
   })
 
   if (error) {
-    message.value = 'Preferences updated successfully'
+    message.value = 'subscribe.preferences.updated'
   }
   else {
     console.error(data)
-    alert('Failed to update preferences. Please try again later.')
+    errorMessage.value = 'subscribe.preferences.update_failed'
   }
 }
 </script>

--- a/opendata.swiss/ui/pages/subscription/preferences.vue
+++ b/opendata.swiss/ui/pages/subscription/preferences.vue
@@ -164,6 +164,10 @@ async function updatePreferences() {
     errorMessage.value = 'subscribe.preferences.update_failed'
   }
 }
+
+useSeoMeta({
+  title: `${t('message.subscribe.preferences.page_title')} | opendata.swiss`,
+})
 </script>
 
 <style scoped>

--- a/opendata.swiss/ui/server/api/subscription/preferences.put.ts
+++ b/opendata.swiss/ui/server/api/subscription/preferences.put.ts
@@ -1,14 +1,14 @@
 import type { Frequency } from '../../lib/listmonk'
 import Listmonk from '../../lib/listmonk'
 import type { AppLanguage } from '~/constants/langages'
-import { validatePreferencesToken } from '#server/lib/listmonk/token'
+import { getIdFromQuery } from '#server/lib/subscription/preferences'
 
 export default defineEventHandler(async (event) => {
   const { listmonk: config } = useRuntimeConfig()
 
   const listmonk = new Listmonk(config)
 
-  const id = validatePreferencesToken(event, config.preferences.hmac_key)
+  const id = await getIdFromQuery(event)
 
   const subscriber = await listmonk.subscribers.get(id)
   subscriber.attribs = subscriber.attribs || {}

--- a/opendata.swiss/ui/server/api/subscription/preferences.ts
+++ b/opendata.swiss/ui/server/api/subscription/preferences.ts
@@ -1,10 +1,10 @@
 import Listmonk from '../../lib/listmonk'
-import { validatePreferencesToken } from '#server/lib/listmonk/token'
+import { getIdFromQuery } from '#server/lib/subscription/preferences'
 
 export default defineEventHandler(async (event) => {
   const { listmonk: config } = useRuntimeConfig()
 
-  const id = validatePreferencesToken(event, config.preferences.hmac_key)
+  const id = await getIdFromQuery(event)
 
   const listmonk = new Listmonk(config)
 

--- a/opendata.swiss/ui/server/lib/subscription/preferences.ts
+++ b/opendata.swiss/ui/server/lib/subscription/preferences.ts
@@ -1,0 +1,31 @@
+import type { H3Event } from 'h3'
+import Listmonk from '#server/lib/listmonk'
+import { validatePreferencesToken } from '#server/lib/listmonk/token'
+
+export async function getIdFromQuery(event: H3Event) {
+  const userSession = await requireUserSession(event)
+
+  const { id, token } = getQuery(event)
+  if (!id) {
+    throw createError({
+      statusCode: 400,
+      message: 'Subscriber ID is required',
+    })
+  }
+
+  const listmonk = useRuntimeConfig().listmonk
+  if (token) {
+    return validatePreferencesToken(event, listmonk.preferences.hmac_key)
+  }
+
+  const subscriber = await new Listmonk(listmonk).subscribers.get(id.toString())
+
+  if (subscriber.email === userSession.user.email) {
+    return id.toString()
+  }
+
+  throw createError({
+    statusCode: 403,
+    message: 'Forbidden',
+  })
+}


### PR DESCRIPTION
1. preferences can now be opened with `token` as long as the user matching subscriber `id` is logged in
2. messages shown in the page and not `alert`
3. translated the whole page and added messages to i18n files
4. possibility of showing error messages
5. page title