### PR TITLE
fix: ending scroll loop when last result is empty

### DIFF
--- a/opendata.swiss/ui/server/lib/piveau.ts
+++ b/opendata.swiss/ui/server/lib/piveau.ts
@@ -98,6 +98,11 @@ export class HubSearch {
         scrollRes = await this._fetch(scrollUrl)
         if (scrollRes.ok) {
           const searchResult: SearchResult<T> = await scrollRes.json()
+
+          if (searchResult.result.results.length === 0) {
+            break
+          }
+
           yield searchResult.result.results
         }
       } while (scrollRes.ok)

--- a/opendata.swiss/ui/server/tests/lib/piveau.test.ts
+++ b/opendata.swiss/ui/server/tests/lib/piveau.test.ts
@@ -81,6 +81,63 @@ describe('HubSearch', () => {
             && url.searchParams.get('scrollId') === 'scroll-123'
         }))
       })
+
+      it('should fetch datasets in pages and return results (last response empty array)', async () => {
+        // given
+        const fetchStub = sinon.stub()
+        fetchStub.onFirstCall().resolves({
+          ok: true,
+          json: async () => ({
+            result: {
+              scrollId: 'scroll-123',
+              results: [{ id: 'ds-1', title: 'Dataset 1' }],
+            },
+          }),
+        })
+        fetchStub.onSecondCall().resolves({
+          ok: true,
+          json: async () => ({
+            result: {
+              scrollId: 'scroll-123',
+              results: [{ id: 'ds-2', title: 'Dataset 2' }],
+            },
+          }),
+        })
+        fetchStub.onThirdCall().resolves({
+          ok: true,
+          json: async () => ({
+            result: {
+              results: [],
+            },
+          }),
+        })
+        const hubSearch = new HubSearch('https://example.com', fetchStub)
+
+        // when
+        const results = []
+        for await (const page of hubSearch.datasets.search().scroll()) {
+          results.push(...page)
+        }
+
+        // then
+        expect(results).to.deep.equal([
+          { id: 'ds-1', title: 'Dataset 1' },
+          { id: 'ds-2', title: 'Dataset 2' },
+        ])
+        expect(fetchStub.firstCall).to.have.been.calledWith(sinon.match((url: URL) => {
+          return url.pathname === '/search'
+            && url.searchParams.get('filters') === 'dataset'
+            && url.searchParams.get('scroll') === 'true'
+        }))
+        expect(fetchStub.secondCall).to.have.been.calledWith(sinon.match((url: URL) => {
+          return url.pathname === '/scroll'
+            && url.searchParams.get('scrollId') === 'scroll-123'
+        }))
+        expect(fetchStub.thirdCall).to.have.been.calledWith(sinon.match((url: URL) => {
+          return url.pathname === '/scroll'
+            && url.searchParams.get('scrollId') === 'scroll-123'
+        }))
+      })
     })
   })
 })


### PR DESCRIPTION
I got the impression that a non-200 response indicates that a scroll is over but it looks like an empty result is actually expected.