### PR TITLE
fix: set default subscription frequency

### DIFF
--- a/opendata.swiss/ui/server/api/subscribe/subscribe.ts
+++ b/opendata.swiss/ui/server/api/subscribe/subscribe.ts
@@ -35,6 +35,7 @@ export function subscribe(key: 'categories' | 'datasets' | 'organisations', fiel
       lists: [],
       attribs: {
         language,
+        frequency: 'daily',
         [key]: values,
       },
     }


### PR DESCRIPTION
Following the change from #276, there must be a frequency for the digest to work