### PR TITLE
showcases: endpoint for harvesting configurable via env var

### DIFF
--- a/opendata.swiss/metadata/docker-compose.yaml
+++ b/opendata.swiss/metadata/docker-compose.yaml
@@ -392,12 +392,15 @@ services:
     logging:
       options:
         max-size: "50m"
+
   piveau-consus-importing-showcases:
     build: ../piveau_modules/piveau-consus-importing-showcases
     restart: unless-stopped
     logging:
       options:
         max-size: "50m"
+    environment:
+      - SHOWCASE_API_ENDPOINT=${SHOWCASE_API_ENDPOINT:-http://piveau-ui/api/showcases}
 
   ####################
   # Listmonk         #

--- a/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
+++ b/opendata.swiss/metadata/piveau_pipes/pipe-showcases-ods.yaml
@@ -13,7 +13,8 @@ body:
         processed: false
       body:
         config:
-          address: http://piveau-ui/api/showcases
+          # setting an address here takes precedence over the value of the SHOWCASE_API_ENDPOINT env variable
+          # address: http://piveau-ui/api/showcases
           # use the address below to harvest from locally-running app
           # address: http://host.docker.internal:3000/api/showcases
           # address: http://172.17.0.1:3000/api/showcases

--- a/opendata.swiss/piveau_modules/piveau-consus-importing-showcases/src/main/java/swiss/opendata/piveau/pipe/module/importing/showcases/MainVerticle.java
+++ b/opendata.swiss/piveau_modules/piveau-consus-importing-showcases/src/main/java/swiss/opendata/piveau/pipe/module/importing/showcases/MainVerticle.java
@@ -4,6 +4,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.piveau.pipe.PipeContext;
 import io.piveau.pipe.connector.PipeConnector;
+import io.vertx.config.ConfigRetriever;
+import io.vertx.config.ConfigRetrieverOptions;
+import io.vertx.config.ConfigStoreOptions;
 import io.vertx.core.AbstractVerticle;
 import io.vertx.core.Future;
 import io.vertx.core.Launcher;
@@ -16,11 +19,31 @@ import java.util.List;
 
 public class MainVerticle extends AbstractVerticle {
 
+    static final String ENV_SHOWCASE_API_ENDPOINT = "SHOWCASE_API_ENDPOINT";
+
+    // falling back to a default address (configurable via SHOWCASE_API_ENDPOINT) in case no address is set in the pipe segment configuration
+    private String showcaseApiAddressDefault;
+
+
     /**
      * The main Vert.x function aka entry point to the application
      */
     @Override
     public void start(Promise<Void> startPromise) throws Exception {
+
+        ConfigStoreOptions envStoreOptions = new ConfigStoreOptions()
+                .setType("env")
+                .setConfig(new JsonObject().put("keys", new JsonArray()
+                        .add(ENV_SHOWCASE_API_ENDPOINT)));
+
+        ConfigRetriever.create(vertx, new ConfigRetrieverOptions().addStore(envStoreOptions))
+                .getConfig()
+                .onSuccess(config -> {
+                    this.showcaseApiAddressDefault = config.getString(ENV_SHOWCASE_API_ENDPOINT);
+                })
+                .<Void>mapEmpty()
+                .onComplete(startPromise);
+
         PipeConnector.create(vertx)
                 .onSuccess(connector -> connector.handlePipe(this::handlePipe))
                 .<Void>mapEmpty()
@@ -36,7 +59,7 @@ public class MainVerticle extends AbstractVerticle {
 
         pipeContext.log().info("Import started.");
 
-        ShowcaseApiConnector connector = ShowcaseApiConnector.create(vertx, pipeContext);
+        ShowcaseApiConnector connector = ShowcaseApiConnector.create(vertx, pipeContext, showcaseApiAddressDefault);
 
         Future.future(connector::fetchAll).onSuccess(v -> {
             List<String> identifiers = connector.getIdentifiers();

--- a/opendata.swiss/piveau_modules/piveau-consus-importing-showcases/src/main/java/swiss/opendata/piveau/pipe/module/importing/showcases/ShowcaseApiConnector.java
+++ b/opendata.swiss/piveau_modules/piveau-consus-importing-showcases/src/main/java/swiss/opendata/piveau/pipe/module/importing/showcases/ShowcaseApiConnector.java
@@ -30,17 +30,24 @@ public class ShowcaseApiConnector {
 
 
     public static ShowcaseApiConnector create(Vertx vertx, PipeContext pipeContext) {
-        return new ShowcaseApiConnector(vertx, pipeContext);
+        return create(vertx, pipeContext, null);
     }
 
-    private ShowcaseApiConnector(Vertx vertx, PipeContext pipeContext) {
+    public static ShowcaseApiConnector create(Vertx vertx, PipeContext pipeContext, String showcaseApiAddressDefault) {
+        return new ShowcaseApiConnector(vertx, pipeContext, showcaseApiAddressDefault);
+    }
+
+    private ShowcaseApiConnector(Vertx vertx, PipeContext pipeContext, String showcaseApiAddressDefault) {
         this.pipeContext = pipeContext;
         this.webClient = WebClient.create(vertx);
 
         JsonObject config = pipeContext.getConfig();
 
         this.catalogue = config.getString("catalogue");
-        this.address = config.getString("address");
+
+        // address from pipe segment configuration takes precedence over default address
+        String addressFromPipeSegmentConfiguration = config.getString("address");
+        this.address = addressFromPipeSegmentConfiguration != null ? addressFromPipeSegmentConfiguration : showcaseApiAddressDefault;
     }
 
     public List<String> getIdentifiers() {
@@ -48,6 +55,7 @@ public class ShowcaseApiConnector {
     }
 
     public void fetchAll(Promise<Void> promise) {
+        pipeContext.log().info("Fetching from address: {} ", address);
         webClient.getAbs(address).send().onSuccess(response -> {
             try {
                 Model model = Piveau.toModel(response.bodyAsString(), Lang.JSONLD);


### PR DESCRIPTION
Makes the endpoint address the showcases are harvested from configurable via environment variable `SHOWCASE_API_ENDPOINT` on the `piveau-consus-importing-showcases` service

It remains possible to configure the endpoint address in the pipe definition (pipe-showcases-ods.yaml) . Doing so takes precedence over the environment variable