### PR TITLE
small search panel

### DIFF
--- a/opendata.swiss/ui/app/components/OdsCmsSearchPage.vue
+++ b/opendata.swiss/ui/app/components/OdsCmsSearchPage.vue
@@ -78,6 +78,7 @@ watch(
       <OdsBreadcrumbs :breadcrumbs="breadcrumbs" />
       <OdsSearchPanel
         v-model:search-input="searchInput"
+        small
         :search-prompt="searchPrompt"
         @search="onSearch"
       />

--- a/opendata.swiss/ui/app/components/OdsSearchPanel.vue
+++ b/opendata.swiss/ui/app/components/OdsSearchPanel.vue
@@ -1,21 +1,23 @@
 <template>
   <section
-    class="section section--default bg--secondary-50"
+    :class="{ 'section section--default bg--secondary-50': !small }"
     :aside="aside ? 'true' : 'false'"
   >
     <div class="container">
-      <h3
-        v-if="aside"
-        class="h3"
-      >
-        {{ title || t('message.dataset_search.search_results') }}
-      </h3>
-      <h1
-        v-else
-        class="h1"
-      >
-        {{ title || t('message.dataset_search.search_results') }}
-      </h1>
+      <template v-if="!small">
+        <h3
+          v-if="aside"
+          class="h3"
+        >
+          {{ title || t('message.dataset_search.search_results') }}
+        </h3>
+        <h1
+          v-else
+          class="h1"
+        >
+          {{ title || t('message.dataset_search.search_results') }}
+        </h1>
+      </template>
       <div class="search search--large search--page-result">
         <div class="search__group">
           <input
@@ -67,6 +69,7 @@ interface PropTypes {
   searchInput: string | string[]
   searchPrompt: string
   aside?: boolean
+  small?: boolean
   title?: string
   facetRefs?: Record<string, Ref<string[]>>
   activeFacets?: SearchResultFacetGroupLocalized[]

--- a/opendata.swiss/ui/pages/blog/[[page]]/index.vue
+++ b/opendata.swiss/ui/pages/blog/[[page]]/index.vue
@@ -72,7 +72,7 @@ const onSearch = (value) => {
     </template>
     <OdsSearchPanel
       v-model:search-input="searchInput"
-      aside
+      small
       :search-prompt="t('message.blog.search_prompt')"
       @search="onSearch"
     />


### PR DESCRIPTION
You can add `small` to the component to just have the input field. It's a very minimal implementation of what we need. 
- just an input field with a placeholder 

It is used in /de/blog/search and /de/blog

The purpose of this PR is to add this functionality to the component and it is not about the usage. We have to think how we can provide consistency to the UI but this is out of scope of the PR.