### PR TITLE
do not ignore data services and series in consus filter

### DIFF
--- a/opendata.swiss/piveau_modules/piveau-consus-filter/src/main/java/swiss/opendata/piveau/pipe/module/filter/MainVerticle.java
+++ b/opendata.swiss/piveau_modules/piveau-consus-filter/src/main/java/swiss/opendata/piveau/pipe/module/filter/MainVerticle.java
@@ -226,8 +226,8 @@ public class MainVerticle extends AbstractVerticle {
             if (config.containsKey("org_id")){
                 sb.append("Organization: ").append(config.getString("org_id")).append("\t");
             }
-            if (config.containsKey("datasetURI")){
-                sb.append("Dataset: ").append(config.getString("datasetURI")).append("\t");
+            if (config.containsKey("identifier")){
+                sb.append("Identifier: ").append(config.getString("identifier")).append("\t");
             }
             for (String error : errors) {
                 sb.append("- ").append(error).append("\t");
@@ -266,28 +266,36 @@ public class MainVerticle extends AbstractVerticle {
             return;
         }
         
-        List<Resource> datasets = model.listResourcesWithProperty(RDF.type, DCAT.Dataset).toList();  
-        if (datasets.size() != 1) {
-            logger.warn("Expected exactly one dcat:Dataset, but found {}. Skipping this pipe execution.", datasets.size());
+        List<Resource> datasets = model.listResourcesWithProperty(RDF.type, DCAT.Dataset).toList();
+        Set<Resource> dcatResources = new HashSet<>(datasets); // the same resource could be both a Dataset and a DatasetSeries, so we use a Set to avoid duplicates
+        dcatResources.addAll(model.listResourcesWithProperty(RDF.type, model.createResource(DCAT.NAMESPACE + "DatasetSeries")).toList());
+        dcatResources.addAll(model.listResourcesWithProperty(RDF.type, DCAT.DataService).toList());
+       
+        if (dcatResources.size() != 1) {
+            logger.warn("Expected exactly one dcat resource (Dataset, DatasetSeries or DataService), but found {}. Skipping this pipe execution.", dcatResources.size());
             return;
         }
-        Resource dataset = datasets.get(0);
+        Resource resource = dcatResources.iterator().next();
 
-        JsonObject config = pipeContext.getConfig();
-        config.put("datasetURI", dataset.getURI());
-        String organizationID = config.getString("org_id");
+        if(datasets.contains(resource)) {
+            // if resource is a Dataset, we perform checks (and possibly make little changes to it)
+            JsonObject config = pipeContext.getConfig();
+            ErrorHandler errorHandler = new ErrorHandler(config);
+            checkIdentifier(model, resource, config.getString("org_id"), errorHandler);
+            checkConformsTo(model, resource, errorHandler);
+            checkLicense(model, resource, errorHandler);
+            checkSpatial(model, resource);
 
-        ErrorHandler errorHandler = new ErrorHandler(config);
-        checkIdentifier(model, dataset, organizationID, errorHandler);
-        checkConformsTo(model, dataset, errorHandler);
-        checkLicense(model, dataset, errorHandler);
-        checkSpatial(model, dataset);
-
-        if (errorHandler.hasErrors()) {
-            errorHandler.notifyErrors();
+            if (errorHandler.hasErrors()) {
+                errorHandler.notifyErrors();
+            } else {
+                logger.info("dataset {}", pipeContext.getDataInfo());
+                pipeContext.setResult(Piveau.presentAs(model, Lang.NTRIPLES), Lang.NTRIPLES.getHeaderString(), pipeContext.getDataInfo()).forward();
+            }
         } else {
-            logger.info("passing {}", pipeContext.getDataInfo());
-            pipeContext.setResult(Piveau.presentAs(model, Lang.NTRIPLES), Lang.NTRIPLES.getHeaderString(), pipeContext.getDataInfo()).forward();
+            logger.info("resource {}", pipeContext.getDataInfo());
+            // we propagate the resource as is, without any checks or modifications
+            pipeContext.pass();
         }
     }
 


### PR DESCRIPTION
At the moment, the filter module is processing only datasets and skipping all the rest.
This PR makes the filter module aware of dataset series and data services.

In case a resource is both a dataset and a dataset series (see `test2` below), it is processed as a dataset.

To help testing things locally, you can use [this branch](https://github.com/opendata-swiss/metadata.swiss/tree/test-file-server) (not meant to be merged) where there is a local file server and a test catalogue and pipe referencing it.

If you put example data in `volumes/file-server/test.ttl` like:

```turtle
@prefix dcat: <http://www.w3.org/ns/dcat#> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix : <http://example.org/> .

[] a dcat:Catalog ;
	dcat:dataset :dataset1, :dataset2 ;
    dcat:service :service1, :service2 .

:dataset1 a dcat:Dataset ;
    dcterms:identifier "test1" ;
    dcterms:license <http://dcat-ap.ch/vocabulary/licenses/terms_by_ask> ;
    dcterms:title "test 1"@en, "test 1"@de, "test 1"@fr ;
    dcat:inSeries :datsetSeries1
.

:dataset2 a dcat:Dataset, dcat:DatasetSeries ;
    dcterms:identifier "test2" ;
    dcterms:license <http://dcat-ap.ch/vocabulary/licenses/terms_by_ask> ;
    dcterms:title "test2"@en, "test2"@de, "test2"@fr ;
.

:service1 a dcat:DataService ;
    dcterms:identifier "test service 1" ;
    dcat:servesDataset :dataset1, :dataset2
.

:service2 a dcat:DataService ;
    dcterms:identifier "test service 2" ;
    dcat:servesDataset :dataset1, :dataset2
.

:datsetSeries1 a dcat:DatasetSeries ;
    dcterms:identifier "test dataset series 1" ;
    dcterms:license <http://dcat-ap.ch/vocabulary/licenses/terms_by_ask> ;
    dcterms:title "test dataset series 1"@en, "test dataset series 1"@de, "test dataset series 1"@fr ;
.

```
and run `./script/harverst.sh test-piveau` you should be able to populate the triple store with dataset series and data services. The indexing phase has still issues, but they are beyond the scope of this PR.
