### PR TITLE
Added rating property to showcases shape

### DIFF
--- a/opendata.swiss/metadata/piveau_profile/showcase.hub.shapes.ttl
+++ b/opendata.swiss/metadata/piveau_profile/showcase.hub.shapes.ttl
@@ -126,5 +126,13 @@ ex:Showcase_Shape a sh:NodeShape ;
           sh:severity sh:Violation ;
           pv:mappingClass "Keywords" ;
           pv:mappingName "keywords"
+      ], [
+          sh:path schema:ratingValue ;
+          sh:nodeKind sh:Literal ;
+          sh:datatype xsd:decimal ;
+          sh:minCount 0 ;
+          sh:maxCount 1 ;
+          pv:mappingClass "Numeric" ;
+          pv:mappingName "rating"
       ]
       .


### PR DESCRIPTION
Adds the `schema:ratingValue` property mapping to the showcase SHACL shape.