### PR TITLE
fix(profile): populate the showcase type facet

### DIFF
--- a/opendata.swiss/metadata/piveau_profile/piveau.json
+++ b/opendata.swiss/metadata/piveau_profile/piveau.json
@@ -41,7 +41,8 @@
             }, {
               "name": "type",
               "title": "Type",
-              "path": "type"
+              "path": "type",
+              "plain": true
             }
         ],
         "searchParams": []


### PR DESCRIPTION
Configure the showcase type facet as a plain field so dct:type values are aggregated correctly.

Refs: https://gitlab.zazuko.tools/opendata.swiss/new-opendata.swiss/-/work_items/244