### PR TITLE
feat: linking showcases and organzations

### DIFF
--- a/opendata.swiss/ui/server/api/showcases.post.ts
+++ b/opendata.swiss/ui/server/api/showcases.post.ts
@@ -134,22 +134,6 @@ export default defineEventHandler(async (event) => {
           })
         }
       })
-      .with(P.string.startsWith('submittedBy'), () => {
-        const submittedBy = showcase.de.submittedBy || {
-          name: undefined,
-          url: [],
-        } as unknown as Required<ShowcasesCollectionItem>['submittedBy']
-
-        match(name as 'submittedBy.name' | 'submittedBy.url')
-          .with('submittedBy.name', () => {
-            submittedBy.name = data.toString()
-          })
-          .with('submittedBy.url', () => {
-            submittedBy.url!.push(data.toString())
-          })
-
-        showcase.de.submittedBy = submittedBy
-      })
       .otherwise(() => {
         console.warn(`Unknown field: ${name}`)
       })

--- a/opendata.swiss/ui/server/api/showcases.ts
+++ b/opendata.swiss/ui/server/api/showcases.ts
@@ -6,6 +6,7 @@ import type { ShowcasesCollectionItem } from '@nuxt/content'
 import { execSync } from 'node:child_process'
 import { join } from 'node:path'
 import { queryCollection } from '@nuxt/content/server'
+import $rdf from '@zazuko/env-node'
 
 const stemPattern = /showcases\/(?<stem>.*)\.(?<lang>\w\w)$/
 
@@ -27,7 +28,7 @@ interface AggregateShowcase {
   'qualifiedAttribution': Array<{
     '@type': 'prov:Attribution'
     'prov:agent': string | {
-      '@type': 'prov:Person' | 'prov:Organization'
+      '@type': 'foaf:Person' | 'foaf:Organization'
       'foaf:name': string
       'foaf:homepage'?: string[]
     }
@@ -202,10 +203,12 @@ function getShowcaseDates(rootDir: string, stem: string) {
   }
 }
 
+const ResponsiblePartyRole = $rdf.namespace('http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/')
+
 function toAttribution(relationship: Required<ShowcasesCollectionItem>['relationships'][number]): AggregateShowcase['qualifiedAttribution'][number] | undefined {
   const attribution: Omit<AggregateShowcase['qualifiedAttribution'][number], 'prov:agent'> = {
     '@type': 'prov:Attribution',
-    'dcat:hadRole': `urn:example:isotc211/CI_RoleCode/${relationship.role}`,
+    'dcat:hadRole': ResponsiblePartyRole(relationship.role).value,
   }
 
   switch (relationship.type) {
@@ -218,7 +221,7 @@ function toAttribution(relationship: Required<ShowcasesCollectionItem>['relation
       return {
         ...attribution,
         'prov:agent': {
-          '@type': 'prov:Person',
+          '@type': 'foaf:Person',
           'foaf:name': relationship.name,
         },
       }
@@ -226,7 +229,7 @@ function toAttribution(relationship: Required<ShowcasesCollectionItem>['relation
       return {
         ...attribution,
         'prov:agent': {
-          '@type': 'prov:Organization',
+          '@type': 'foaf:Organization',
           'foaf:name': relationship.name,
           'foaf:homepage': relationship.url || [],
         },

--- a/opendata.swiss/ui/server/api/showcases.ts
+++ b/opendata.swiss/ui/server/api/showcases.ts
@@ -204,6 +204,7 @@ function getShowcaseDates(rootDir: string, stem: string) {
 }
 
 const ResponsiblePartyRole = $rdf.namespace('http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/')
+const Organization = $rdf.namespace('https://opendata.swiss/id/organization/')
 
 function toAttribution(relationship: Required<ShowcasesCollectionItem>['relationships'][number]): AggregateShowcase['qualifiedAttribution'][number] | undefined {
   const attribution: Omit<AggregateShowcase['qualifiedAttribution'][number], 'prov:agent'> = {
@@ -215,7 +216,7 @@ function toAttribution(relationship: Required<ShowcasesCollectionItem>['relation
     case 'organization':
       return {
         ...attribution,
-        'prov:agent': `https://opendata.swiss/id/organization/${relationship.organization[0]!.id}`,
+        'prov:agent': Organization(relationship.organization[0]!.id).value,
       }
     case 'person':
       return {

--- a/opendata.swiss/ui/server/api/showcases.ts
+++ b/opendata.swiss/ui/server/api/showcases.ts
@@ -1,7 +1,7 @@
 import { remark } from 'remark'
 import strip from 'strip-markdown'
 import remarkFrontmatter from 'remark-frontmatter'
-import { dcat, dcterms, rdfs, schema, xsd } from '@tpluscode/rdf-ns-builders'
+import { dcat, dcterms, rdfs, schema, xsd, prov, foaf } from '@tpluscode/rdf-ns-builders'
 import type { ShowcasesCollectionItem } from '@nuxt/content'
 import { execSync } from 'node:child_process'
 import { join } from 'node:path'
@@ -24,51 +24,75 @@ interface AggregateShowcase {
   'modified': string | undefined
   'issued': string | undefined
   'pinned': boolean
+  'qualifiedAttribution': Array<{
+    '@type': 'prov:Attribution'
+    'prov:agent': string | {
+      '@type': 'prov:Person' | 'prov:Organization'
+      'foaf:name': string
+      'foaf:homepage'?: string[]
+    }
+    'dcat:hadRole': string
+  }>
 }
 
 const ldContext = {
-  id: '@id',
-  label: rdfs.label.value,
-  type: {
+  'id': '@id',
+  'dcat': dcat().value,
+  'prov': prov().value,
+  'label': rdfs.label.value,
+  'foaf': foaf().value,
+  'foaf:homepage': {
+    '@type': '@id',
+  },
+  'type': {
     '@id': dcterms.type.value,
     '@type': '@id',
   },
-  categories: {
+  'categories': {
     '@id': dcat.theme.value,
     '@type': '@id',
   },
-  datasets: {
+  'datasets': {
     '@id': dcterms.references.value,
     '@type': '@id',
   },
-  title: {
+  'title': {
     '@id': dcterms.title.value,
     '@container': '@language',
   },
-  abstract: {
+  'abstract': {
     '@id': dcterms.abstract.value,
     '@container': '@language',
   },
-  text: {
+  'text': {
     '@id': schema.text.value,
     '@container': '@language',
   },
-  pinned: {
+  'pinned': {
     '@id': 'piveau:pinned',
     '@type': xsd.boolean.value,
   },
-  identifier: dcterms.identifier.value,
-  image: schema.image.value,
-  tag: dcat.keyword.value,
-  modified: dcterms.modified.value,
-  issued: dcterms.issued.value,
-  Dataset: dcat.Dataset.value,
-  piveau: 'https://piveau.eu/ns/voc#',
+  'dcat:hadRole': {
+    '@id': 'dcat:hadRole',
+    '@type': '@id',
+  },
+  'prov:agent': {
+    '@id': 'prov:agent',
+    '@type': '@id',
+  },
+  'identifier': dcterms.identifier.value,
+  'image': schema.image.value,
+  'tag': dcat.keyword.value,
+  'modified': dcterms.modified.value,
+  'issued': dcterms.issued.value,
+  'Dataset': dcat.Dataset.value,
+  'piveau': 'https://piveau.eu/ns/voc#',
+  'qualifiedAttribution': prov.qualifiedAttribution.value,
 }
 export default defineEventHandler(async (event) => {
   const { public: { rootDir } } = useRuntimeConfig(event)
   const showcases = await queryCollection(event, 'showcases')
-    .select('title', 'categories', 'datasets', 'description', 'rawbody', 'stem', 'image', 'tags', 'type', 'pinned')
+    .select('title', 'categories', 'datasets', 'description', 'rawbody', 'stem', 'image', 'tags', 'type', 'pinned', 'relationships')
     .where('active', '=', true)
     .all()
 
@@ -100,6 +124,7 @@ export default defineEventHandler(async (event) => {
         'pinned': showcase.pinned || false,
         modified,
         issued,
+        'qualifiedAttribution': [],
       }
       arr.push(aggregate)
     }
@@ -107,6 +132,11 @@ export default defineEventHandler(async (event) => {
     aggregate.title[lang] = showcase.title || undefined
     aggregate.abstract[lang] = showcase.description || undefined
     aggregate.text[lang] = await stripMarkdown(showcase.rawbody) || undefined
+    if (lang === 'de') {
+      aggregate.qualifiedAttribution = showcase.relationships
+        ?.map(toAttribution)
+        .filter(qa => !!qa) || []
+    }
 
     return arr
   }, Promise.resolve<AggregateShowcase[]>([]))
@@ -169,5 +199,39 @@ function getShowcaseDates(rootDir: string, stem: string) {
       modified: undefined,
       issued: undefined,
     }
+  }
+}
+
+function toAttribution(relationship: Required<ShowcasesCollectionItem>['relationships'][number]): AggregateShowcase['qualifiedAttribution'][number] | undefined {
+  const attribution: Omit<AggregateShowcase['qualifiedAttribution'][number], 'prov:agent'> = {
+    '@type': 'prov:Attribution',
+    'dcat:hadRole': `urn:example:isotc211/CI_RoleCode/${relationship.role}`,
+  }
+
+  switch (relationship.type) {
+    case 'organization':
+      return {
+        ...attribution,
+        'prov:agent': `https://opendata.swiss/id/organization/${relationship.organization[0]!.id}`,
+      }
+    case 'person':
+      return {
+        ...attribution,
+        'prov:agent': {
+          '@type': 'prov:Person',
+          'foaf:name': relationship.name,
+        },
+      }
+    case 'organization-external':
+      return {
+        ...attribution,
+        'prov:agent': {
+          '@type': 'prov:Organization',
+          'foaf:name': relationship.name,
+          'foaf:homepage': relationship.url || [],
+        },
+      }
+    default:
+      return undefined
   }
 }

--- a/opendata.swiss/ui/server/tests/showcases.test.n3
+++ b/opendata.swiss/ui/server/tests/showcases.test.n3
@@ -1,3 +1,7 @@
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+PREFIX prov: <http://www.w3.org/ns/prov#>
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX string: <http://www.w3.org/2000/10/swap/string#>
 prefix list: <http://www.w3.org/2000/10/swap/list#>
 PREFIX piveau: <https://piveau.eu/ns/voc#>
@@ -42,6 +46,62 @@ prefix theme: <http://publications.europa.eu/resource/authority/data-theme/>
     {
       ?body log:includes {
         </showcase/showcase> dcat:theme theme:SOCI, theme:REGI.
+      } .
+    }!tuner:assertThat .
+  } ;
+.
+
+<#organization-attribution>
+  a earl:TestCase ;
+  rdfs:label "Organzation attributions are exported" ;
+  tuner:formula {
+    (</api/showcases> ?res) resource:getIn [] .
+
+    ?res tuner:body ?body .
+    {
+      ?body log:includes {
+        </showcase/showcase> prov:qualifiedAttribution ?qa .
+        ?qa dcat:hadRole <urn:example:isotc211/CI_RoleCode/author> ;
+            prov:agent <https://opendata.swiss/id/organization/ch-bafu> .
+      } .
+    }!tuner:assertThat .
+  } ;
+.
+
+<#external-organization-attribution>
+  a earl:TestCase ;
+  rdfs:label "External Organzation attributions are exported" ;
+  tuner:formula {
+    (</api/showcases> ?res) resource:getIn [] .
+
+    ?res tuner:body ?body .
+    {
+      ?body log:includes {
+        </showcase/showcase> prov:qualifiedAttribution ?qa .
+        ?qa dcat:hadRole <urn:example:isotc211/CI_RoleCode/collaborator> ;
+            prov:agent ?agent .
+        ?agent a prov:Organization ;
+               foaf:name "Foobar" ;
+               foaf:homepage <http://example.com/foobar> .
+      } .
+    }!tuner:assertThat .
+  } ;
+.
+
+<#person-attribution>
+  a earl:TestCase ;
+  rdfs:label "Person attributions are exported" ;
+  tuner:formula {
+    (</api/showcases> ?res) resource:getIn [] .
+
+    ?res tuner:body ?body .
+    {
+      ?body log:includes {
+        </showcase/showcase> prov:qualifiedAttribution ?qa .
+        ?qa dcat:hadRole <urn:example:isotc211/CI_RoleCode/author> ;
+            prov:agent ?agent .
+         ?agent a prov:Person ;
+                foaf:name "John Doe" .
       } .
     }!tuner:assertThat .
   } ;

--- a/opendata.swiss/ui/server/tests/showcases.test.n3
+++ b/opendata.swiss/ui/server/tests/showcases.test.n3
@@ -61,7 +61,7 @@ prefix theme: <http://publications.europa.eu/resource/authority/data-theme/>
     {
       ?body log:includes {
         </showcase/showcase> prov:qualifiedAttribution ?qa .
-        ?qa dcat:hadRole <urn:example:isotc211/CI_RoleCode/author> ;
+        ?qa dcat:hadRole <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/author> ;
             prov:agent <https://opendata.swiss/id/organization/ch-bafu> .
       } .
     }!tuner:assertThat .
@@ -78,9 +78,9 @@ prefix theme: <http://publications.europa.eu/resource/authority/data-theme/>
     {
       ?body log:includes {
         </showcase/showcase> prov:qualifiedAttribution ?qa .
-        ?qa dcat:hadRole <urn:example:isotc211/CI_RoleCode/collaborator> ;
+        ?qa dcat:hadRole <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/resourceProvider> ;
             prov:agent ?agent .
-        ?agent a prov:Organization ;
+        ?agent a foaf:Organization ;
                foaf:name "Foobar" ;
                foaf:homepage <http://example.com/foobar> .
       } .
@@ -98,9 +98,9 @@ prefix theme: <http://publications.europa.eu/resource/authority/data-theme/>
     {
       ?body log:includes {
         </showcase/showcase> prov:qualifiedAttribution ?qa .
-        ?qa dcat:hadRole <urn:example:isotc211/CI_RoleCode/author> ;
+        ?qa dcat:hadRole <http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/author> ;
             prov:agent ?agent .
-         ?agent a prov:Person ;
+         ?agent a foaf:Person ;
                 foaf:name "John Doe" .
       } .
     }!tuner:assertThat .

--- a/opendata.swiss/ui/src/admin/OrganizationSearchComponent.jsx
+++ b/opendata.swiss/ui/src/admin/OrganizationSearchComponent.jsx
@@ -7,29 +7,23 @@ import React from 'react'
 // filtered by the search endpoint, so no need to do it again.
 const filterBy = () => true
 
-export default class ShowcaseSearchComponent extends PiveauSearchComponent {
+export default class OrganizationSearchComponent extends PiveauSearchComponent {
   state = {
     options: toArray(this.props.value),
   }
 
   get filter() {
-    return 'resource'
+    return 'organization'
   }
 
   get labelProp() {
-    return 'title'
+    return 'name'
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.value !== this.props.value) {
       this.setState({ options: toArray(this.props.value) })
     }
-  }
-
-  prepareSearchUrl(searchParams) {
-    const url = super.prepareSearchUrl(searchParams)
-    url.searchParams.set('resource', 'showcase')
-    return url
   }
 
   handleSearch = async (q) => {

--- a/opendata.swiss/ui/src/admin/config.yml
+++ b/opendata.swiss/ui/src/admin/config.yml
@@ -238,6 +238,66 @@ collections:
         widget: string
         i18n: duplicate
         required: false
+      - label: Relationships
+        name: relationships
+        i18n: false
+        required: false
+        widget: list
+        types:
+          - label: Organization
+            name: organization
+            widget: object
+            summary: '{{fields.organization}} ({{fields.role}})'
+            fields:
+              - label: Organization
+                name: organization
+                widget: piveau-organization
+                piveau:
+                  search: https://piveau-hub-search.test.ods.zazukoians.org/
+              - label: Role
+                name: role
+                widget: select
+                options:
+                  - label: Author
+                    value: author
+                  - label: Collaborator
+                    value: collaborator
+          - label: External organization
+            name: organization-external
+            widget: object
+            summary: '{{fields.name}} ({{fields.role}})'
+            fields:
+              - label: Name
+                name: name
+                widget: string
+              - name: url
+                label: Url (separate multiple entries with a comma)
+                widget: list
+                required: false
+              - label: Role
+                name: role
+                widget: select
+                options:
+                  - label: Author
+                    value: author
+                  - label: Collaborator
+                    value: collaborator
+          - label: Person
+            name: person
+            widget: object
+            summary: '{{fields.name}} ({{fields.role}})'
+            fields:
+              - label: Name
+                name: name
+                widget: string
+              - label: Role
+                name: role
+                widget: select
+                options:
+                  - label: Author
+                    value: author
+                  - label: Collaborator
+                    value: collaborator
       - label: Category
         name: categories
         widget: piveau-vocabulary
@@ -264,21 +324,6 @@ collections:
       - name: tags
         label: Tags
         widget: list
-      - name: submittedBy
-        label: Submitted by
-        widget: object
-        summary: '{{fields.name}}'
-        required: false
-        i18n: false
-        fields:
-          - name: name
-            label: Name
-            widget: string
-            required: false
-          - name: url
-            label: Url (separate multiple entries with a comma)
-            widget: list
-            required: false
       - name: body
         label: Body
         widget: markdown

--- a/opendata.swiss/ui/src/admin/config.yml
+++ b/opendata.swiss/ui/src/admin/config.yml
@@ -254,14 +254,34 @@ collections:
                 widget: piveau-organization
                 piveau:
                   search: https://piveau-hub-search.test.ods.zazukoians.org/
-              - label: Role
+              - &role_field
+                label: Role
                 name: role
                 widget: select
+                hint: Extracted from http://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole
                 options:
                   - label: Author
                     value: author
-                  - label: Collaborator
-                    value: collaborator
+                  - label: Custodian
+                    value: custodian
+                  - label: Distributor
+                    value: distributor
+                  - label: Originator
+                    value: originator
+                  - label: Owner
+                    value: owner
+                  - label: Point of contact
+                    value: pointOfContact
+                  - label: Principal investigator
+                    value: principalInvestigator
+                  - label: Processor
+                    value: processor
+                  - label: Publisher
+                    value: publisher
+                  - label: Resource provider
+                    value: resourceProvider
+                  - label: User
+                    value: user
           - label: External organization
             name: organization-external
             widget: object
@@ -274,14 +294,7 @@ collections:
                 label: Url (separate multiple entries with a comma)
                 widget: list
                 required: false
-              - label: Role
-                name: role
-                widget: select
-                options:
-                  - label: Author
-                    value: author
-                  - label: Collaborator
-                    value: collaborator
+              - *role_field
           - label: Person
             name: person
             widget: object
@@ -290,14 +303,7 @@ collections:
               - label: Name
                 name: name
                 widget: string
-              - label: Role
-                name: role
-                widget: select
-                options:
-                  - label: Author
-                    value: author
-                  - label: Collaborator
-                    value: collaborator
+              - *role_field
       - label: Category
         name: categories
         widget: piveau-vocabulary

--- a/opendata.swiss/ui/src/admin/piveauWidgets.jsx
+++ b/opendata.swiss/ui/src/admin/piveauWidgets.jsx
@@ -3,6 +3,7 @@ import DatasetSearchComponent from './DatasetSearchComponent'
 import DatasetPreviewComponent from './DatasetPreviewComponent'
 import VocabularySelectComponent from './VocabularySelectComponent.jsx'
 import ShowcaseSearchComponent from './ShowcaseSearchComponent.jsx'
+import OrganizationSearchComponent from './OrganizationSearchComponent.jsx'
 
 CMS.registerWidget('piveau-dataset', DatasetSearchComponent, DatasetPreviewComponent, {
   properties: {
@@ -18,6 +19,19 @@ CMS.registerWidget('piveau-dataset', DatasetSearchComponent, DatasetPreviewCompo
 })
 
 CMS.registerWidget('piveau-showcase', ShowcaseSearchComponent, {
+  properties: {
+    piveau: {
+      type: 'object',
+      properties: {
+        search: {
+          type: 'string',
+        },
+      },
+    },
+  },
+})
+
+CMS.registerWidget('piveau-organization', OrganizationSearchComponent, {
   properties: {
     piveau: {
       type: 'object',

--- a/opendata.swiss/ui/src/admin/vite.config.ts
+++ b/opendata.swiss/ui/src/admin/vite.config.ts
@@ -1,35 +1,7 @@
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 import { defineConfig } from 'vite'
 import { viteStaticCopy } from 'vite-plugin-static-copy'
-import yaml from 'js-yaml'
-
-const piveauHubSearch = process.env.NUXT_PUBLIC_PIVEAU_HUB_SEARCH_URL
-
-interface Field {
-  label: string
-  name: string
-  widget: string
-}
-interface PiveauVocabularyField extends Field {
-  widget: 'piveau-vocabulary'
-  piveau: {
-    search: string
-  }
-}
-
-interface DecapConfig {
-  backend: {
-    repo: string
-  }
-  local_backend?: {
-    url: string
-  }
-  media_folder: string
-  collections: Array<{
-    folder: string
-    fields: Array<Field | PiveauVocabularyField>
-  }>
-}
+import { transform } from './vite/configTransform.js'
 
 export default defineConfig({
   base: '/admin',
@@ -44,48 +16,7 @@ export default defineConfig({
         {
           src: 'config.yml',
           dest: '',
-          transform(content, filename) {
-            if (!filename.endsWith('config.yml')) {
-              return content
-            }
-
-            const config = yaml.load(content) as DecapConfig
-
-            if (process.env.NODE_ENV === 'development') {
-              // In development, we want to use the local backend
-              // and local piveau, if configured in .env
-
-              config.local_backend = {
-                url: 'http://localhost:8088/api/v1',
-              }
-
-              // add path leading to the local content clone
-              config.media_folder = `opendata.swiss/ui/content/${config.media_folder}`
-
-              for (const collection of config.collections) {
-                collection.folder = `opendata.swiss/ui/content/${collection.folder}`
-
-                for (const field of collection.fields) {
-                  if ('piveau' in field && piveauHubSearch) {
-                    field.piveau.search = piveauHubSearch
-                  }
-                }
-              }
-            }
-            else {
-              config.backend.repo = `${process.env.GITHUB_OWNER}/${process.env.GITHUB_CMS_REPO}`
-
-              for (const collection of config.collections) {
-                for (const field of collection.fields) {
-                  if ('piveau' in field && piveauHubSearch) {
-                    field.piveau.search = piveauHubSearch
-                  }
-                }
-              }
-            }
-
-            return yaml.dump(config)
-          },
+          transform,
         },
       ],
     }),

--- a/opendata.swiss/ui/src/admin/vite/configTransform.ts
+++ b/opendata.swiss/ui/src/admin/vite/configTransform.ts
@@ -1,0 +1,102 @@
+import type { TransformFunc } from 'vite-plugin-static-copy'
+import * as yaml from 'js-yaml'
+
+const piveauHubSearch = process.env.NUXT_PUBLIC_PIVEAU_HUB_SEARCH_URL
+
+interface FieldBase {
+  label: string
+  name: string
+  widget: string
+  types: ObjectField[]
+}
+interface ObjectField extends FieldBase {
+  fields: Field[]
+}
+interface SelectField extends FieldBase {
+  options: Array<{ label: string, value: string }>
+}
+interface OrganizationsSelectField extends SelectField {
+  name: 'organization'
+  widget: 'select'
+}
+interface PiveauVocabularyField extends FieldBase {
+  widget: 'piveau-vocabulary'
+  piveau: {
+    search: string
+  }
+}
+
+type Field = OrganizationsSelectField | PiveauVocabularyField
+
+interface DecapConfig {
+  backend: {
+    repo: string
+  }
+  local_backend?: {
+    url: string
+  }
+  media_folder: string
+  collections: Array<{
+    folder: string
+    fields: Array<Field>
+  }>
+}
+
+export const transform: TransformFunc<string> = async (content, filename) => {
+  if (!filename.endsWith('config.yml')) {
+    return content
+  }
+
+  if (!piveauHubSearch) {
+    console.log('No piveauHubSearch configured')
+  }
+
+  const config = yaml.load(content) as DecapConfig
+
+  if (process.env.NODE_ENV === 'development') {
+    // In development, we want to use the local backend
+    // and local piveau, if configured in .env
+
+    config.local_backend = {
+      url: 'http://localhost:8088/api/v1',
+    }
+
+    // add path leading to the local content clone
+    config.media_folder = `opendata.swiss/ui/content/${config.media_folder}`
+
+    for (const collection of config.collections) {
+      collection.folder = `opendata.swiss/ui/content/${collection.folder}`
+
+      for (const field of collection.fields) {
+        await processField(field)
+      }
+    }
+  }
+  else {
+    config.backend.repo = `${process.env.GITHUB_OWNER}/${process.env.GITHUB_CMS_REPO}`
+
+    for (const collection of config.collections) {
+      for (const field of collection.fields) {
+        await processField(field)
+      }
+    }
+  }
+
+  return yaml.dump(config)
+}
+
+async function processField(field: Field) {
+  if ('piveau' in field) {
+    if (piveauHubSearch) {
+      field.piveau.search = piveauHubSearch
+    }
+  }
+
+  if ('types' in field) {
+    for (const type of field.types ?? []) {
+      for (const typeField of type.fields) {
+        await processField(typeField)
+      }
+    }
+  }
+}

--- a/opendata.swiss/ui/src/schema/showcase.ts
+++ b/opendata.swiss/ui/src/schema/showcase.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod/v4'
 import { APP_LANGUAGES } from '../../app/constants/langages.js'
 
+export const relationshipRole = z.enum([
+  'author',
+  'collaborator',
+])
+
 export const shape = {
   active: z.boolean(),
   pinned: z.boolean(),
@@ -13,11 +18,30 @@ export const shape = {
     id: z.string(),
     label: z.string(),
   })).optional(),
+  relationships: z.array(
+    z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('organization'),
+        organization: z.array(z.object({
+          id: z.string(),
+          label: z.string(),
+        })).nonempty(),
+        role: relationshipRole,
+      }),
+      z.object({
+        type: z.literal('organization-external'),
+        name: z.string(),
+        url: z.array(z.string()).optional(),
+        role: relationshipRole,
+      }),
+      z.object({
+        type: z.literal('person'),
+        name: z.string(),
+        role: relationshipRole,
+      }),
+    ]),
+  ).optional(),
   tags: z.array(z.string()).optional(),
-  submittedBy: z.object({
-    name: z.string(),
-    url: z.array(z.url()).optional(),
-  }).optional(),
   rawbody: z.string().optional(),
 }
 


### PR DESCRIPTION
TL;DR:, the CMS is now configured with three kinds of showcase relationships: Person, Organization, and External Organization. Each one has one of two roles (author and collaborator), mapped to [ISO-19115-1](https://standards.iso.org/iso/19115/resources/Codelists/gml/CI_RoleCode.xml) as shown in [dcat docs of `prov:qualifiedAttribution`](https://www.w3.org/TR/vocab-dcat-3/#qualified-attribution)

What do we do about `urn:example:isotc211/CI_RoleCode/`? Use our opendata.swiss URLs instead?