### PR TITLE
log errors in json

### DIFF
--- a/opendata.swiss/metadata/scripts/extract_error_report.sh
+++ b/opendata.swiss/metadata/scripts/extract_error_report.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# docker logs -f metadata-piveau-consus-filter-1 | ./scripts/extract_error_report.sh
+
+set -eu
+
+CURRENT_DATE=$(date +%Y-%m-%d)
+
+# get start date from input argument or use current date if not provided
+START_DATE="${1:-$CURRENT_DATE}"
+
+# Extract JSON payload from logged errors for date $START_DATE
+sed -n "/^$START_DATE/,\$ { /Validation error/ { s/.*\({.*}\).*/\1/p; } }"
+

--- a/opendata.swiss/piveau_modules/piveau-consus-filter/src/main/java/swiss/opendata/piveau/pipe/module/filter/MainVerticle.java
+++ b/opendata.swiss/piveau_modules/piveau-consus-filter/src/main/java/swiss/opendata/piveau/pipe/module/filter/MainVerticle.java
@@ -30,6 +30,9 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 public class MainVerticle extends AbstractVerticle {
 
     private static final Logger logger = LoggerFactory.getLogger(MainVerticle.class);
@@ -220,23 +223,23 @@ public class MainVerticle extends AbstractVerticle {
 
         public void notifyErrors() {
             if (!hasErrors()) return;
-            
-            StringBuilder sb = new StringBuilder();
-            if(config.containsKey("catalogue")){
-                sb.append("Catalogue: ").append(config.getString("catalogue")).append("\t");
-            }
-            if (config.containsKey("org_id")){
-                sb.append("Organization: ").append(config.getString("org_id")).append("\t");
-            }
-            if (dataInfo.containsKey("identifier")){
-                sb.append("Identifier: ").append(dataInfo.getString("identifier")).append("\t");
-            }
-            for (String error : errors) {
-                sb.append("- ").append(error).append("\t");
-            }
-            String message = sb.toString();
 
-            logger.error(message);
+            for (String error : errors) {
+                ObjectNode logData = new ObjectMapper().createObjectNode();
+                if(config.containsKey("catalogue")){
+                    logData.put("catalogue", config.getString("catalogue"));
+                }
+                if (config.containsKey("org_id")){
+                    logData.put("organization", config.getString("org_id"));
+                }   
+                if (dataInfo.containsKey("identifier")){
+                    logData.put("identifier", dataInfo.getString("identifier"));
+                }
+                logData.put("error", error);
+
+                logger.error("Validation error: {}", logData);
+            }
+
             if (config.containsKey("mailto")) {
                 logger.trace("TODO: Notify data publisher at {}", config.getString("mailto"));
             }   


### PR DESCRIPTION
logging errors as JSON objects instead of raw strings, a simple `sed` command can extract error data from the logs