### PR TITLE
uat-collaboration: align document to "Ready for Review" status

### DIFF
--- a/opendata.swiss/system-delivery/uat-collaboration.md
+++ b/opendata.swiss/system-delivery/uat-collaboration.md
@@ -4,9 +4,10 @@ This document describes the collaboration between the development team and the c
 
 | Feature Status | Additional Label | What it means in practice | Who owns it? |
 | :--- | :--- | :--- | :--- |
-| **In Progress** |  | Work is active. Feature is not yet available in the Test environment. | Developer |
-| **Done** | `Test-Ready` | **Handover Point:** Code is merged, feature passed internal QA, and is live in the ABN environment for the customer to test. | Developer (to signal) |
-| **Done** | `BLOCKED` | **Defect Found:** A defect (bug) is preventing sign-off. The original feature stays in "Done" while the defect is fixed. | Customer (to report) |
+| **In Progress** |  | Work is ongoing. | Developer |
+| **Done** |  | Code is merged and feature is live in the REF environment. | Developer |
+| **Ready for Review** |  | **Handover Point:** Feature passed internal QA, and is live in the ABN environment for the customer to test. | Developer (to signal) |
+| **Ready for Review** | `BLOCKED` | **Defect Found:** A defect (bug) is preventing sign-off. The original feature stays in "Ready for Review" while the defect is fixed. | Customer (to report) |
 | **Reviewed** |  | **Final Acceptance:** The feature is verified and signed off by the customer. | Customer |
 
 
@@ -17,10 +18,9 @@ This document describes the collaboration between the development team and the c
 
 One of the biggest friction points in end-user testing is the customer trying to test something that isn't actually ready or deployed. To prevent this, we use the following steps to signal the **Handover**:
 
-When a developer is done with a feature, she does these three things:
-1.  Move the ticket to the **Done** column.
+When a feature is done and live in the ABN environment for the customer to test, the developer does these two things:
+1.  Move the ticket to the **Ready for Review** column.
 2.  **Assign** the ticket to the Customer/Tester.
-3.  Add the **`Test-Ready`** label to the ticket
 
 
 
@@ -33,7 +33,7 @@ When the customer finds a defect, they follow these steps:
 4.  **Assign the defect** to the developer.
 5.  **Flag the feature:** Go to the feature and add the **`BLOCKED`** label.
 
-The original feature stays in "Done" while the defect is fixed. If a developer sees a ticket in "Done" with a `BLOCKED` label, they know testing has stalled.
+The original feature stays in "Ready for Review" while the defect is fixed. If a developer sees a ticket in "Ready for Review" with a `BLOCKED` label, they know testing has stalled.
 
 
 * **Defect Lifecycle:** A defect ticket follows the same workflow as a feature: `To-Do` $\rightarrow$ `In Progress` $\rightarrow$ `Done`.
@@ -49,6 +49,5 @@ The original feature stays in "Done" while the defect is fixed. If a developer s
 
 ### Label Glossary
 
-* **`Test-Ready`**: Applied by the developer to indicate the feature is done, deployed in the test environment and ready for customer testing.
 * **`Defect`**: Applied by the customer to any new issues created to report defects found during testing.
 * **`BLOCKED`**: Applied by the customer to the original feature ticket to signal that a defect is preventing a features acceptance.


### PR DESCRIPTION
I adapted the document so it fits the newly introduced `Ready for Review` column, instead of the `Test-Ready` label as it was described originally