### PR TITLE
Vocab fixes

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-# cd opendata.swiss/ui && npx lint-staged
+cd opendata.swiss/ui && npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-cd opendata.swiss/ui && npx lint-staged
+# cd opendata.swiss/ui && npx lint-staged

--- a/opendata.swiss/ui/app/components/dataset-detail/OdsDatasetDetailHeader.vue
+++ b/opendata.swiss/ui/app/components/dataset-detail/OdsDatasetDetailHeader.vue
@@ -36,7 +36,7 @@
             class="meta-item"
           >
             <span class="meta-label">{{ t('message.dataset_detail.frequency') }}</span>
-            <span class="frequency-text">{{ props.dataset.frequency.label }}</span>
+            <span class="frequency-text">{{ props.dataset.frequencyForLanguage(locale) }}</span>
           </div>
         </div>
       </div>

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -6,6 +6,8 @@ import type { Catalog } from '~/piveau/get-ods-catalog-info'
 import type { TagItem } from '../../OdsTagItem.vue'
 import type { AppLanguage } from '~/constants/langages'
 import { APP_LANGUAGES } from '~/constants/langages'
+import type { } from '@piveau/sdk-core'
+import type { an } from 'vue-router/dist/index-BQLwgiyK.js'
 
 export class DcatApChV2DatasetAdapter {
   #dataset: Dataset
@@ -87,20 +89,11 @@ export class DcatApChV2DatasetAdapter {
         console.warn(`No labels for category\ndataset title: ${this.#dataset.getTitle}\ndataset: ${this.#dataset.getId}\nid: ${cat.id}\nresource: <${cat.resource}>\nlabels: ${cat.label}`)
         return []
       }
-      let preferredLabel = cat.label[lang]
+      const preferredLabel = this.getLabelByLangagePrecedence(lang, cat)
       if (!preferredLabel) {
-        // Try other APP_LANGUAGES
-        for (const fallbackLang of APP_LANGUAGES) {
-          if (cat.label[fallbackLang]) {
-            preferredLabel = cat.label[fallbackLang]
-            break
-          }
-        }
+        return []
       }
-      // If still undefined, take any available label
-      if (!preferredLabel) {
-        preferredLabel = Object.values(cat.label)[0] ?? ''
-      }
+
       const tagItem = {
         id: cat.id,
         label: preferredLabel,
@@ -285,6 +278,17 @@ export class DcatApChV2DatasetAdapter {
     return this.#dataset.getOdsAccrualPeriodicity
   }
 
+  frequencyForLanguage(lang: string) {
+    const frequencyResource = this.frequency
+    if (!frequencyResource) {
+      return undefined
+    }
+    if (!frequencyResource.label) {
+      return undefined
+    }
+    return this.getLabelByLangagePrecedence(lang, frequencyResource as unknown as any)
+  }
+
   get propertyTable() {
     const rootNode = this.#dataset.getPropertyTable
 
@@ -307,5 +311,37 @@ export class DcatApChV2DatasetAdapter {
       newTableEntry.addPiveauPropertyTableEntry(node.data || [])
     }
     return newTableEntries.sort((a, b) => a.label.localeCompare(b.label))
+  }
+
+  /**
+   * Get the label with langage precedence.
+   * @param lang the langage
+   * @param resource  the available labels
+   * @returns a string of the best label candidate available
+   */
+  private getLabelByLangagePrecedence(
+    lang: string,
+    resource: { label?: Record<string, string | undefined> | undefined },
+  ): string {
+    const labels = resource.label
+    if (!labels) {
+      return ''
+    }
+
+    let preferredLabel = labels[lang]
+    if (!preferredLabel) {
+      for (const fallbackLang of APP_LANGUAGES) {
+        if (labels[fallbackLang]) {
+          preferredLabel = labels[fallbackLang]
+          break
+        }
+      }
+    }
+
+    if (!preferredLabel) {
+      preferredLabel = Object.values(labels)[0] ?? ''
+    }
+
+    return preferredLabel
   }
 }

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -7,7 +7,6 @@ import type { TagItem } from '../../OdsTagItem.vue'
 import type { AppLanguage } from '~/constants/langages'
 import { APP_LANGUAGES } from '~/constants/langages'
 import type { } from '@piveau/sdk-core'
-import type { an } from 'vue-router/dist/index-BQLwgiyK.js'
 
 export class DcatApChV2DatasetAdapter {
   #dataset: Dataset
@@ -286,7 +285,7 @@ export class DcatApChV2DatasetAdapter {
     if (!frequencyResource.label) {
       return undefined
     }
-    return this.getLabelByLangagePrecedence(lang, frequencyResource as unknown as any)
+    return this.getLabelByLangagePrecedence(lang, frequencyResource as unknown as { label?: Record<string, string | undefined> | undefined })
   }
 
   get propertyTable() {

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -6,7 +6,6 @@ import type { Catalog } from '~/piveau/get-ods-catalog-info'
 import type { TagItem } from '../../OdsTagItem.vue'
 import type { AppLanguage } from '~/constants/langages'
 import { APP_LANGUAGES } from '~/constants/langages'
-import type { } from '@piveau/sdk-core'
 
 export class DcatApChV2DatasetAdapter {
   #dataset: Dataset

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -79,7 +79,14 @@ export class DcatApChV2DatasetAdapter {
    */
   getCategoriesForLanguage(lang: AppLanguage): TagItem[] {
     const categories = this.#dataset?.getCategories ?? []
-    const tagItems = categories.map((cat) => {
+    const tagItems = categories.flatMap((cat) => {
+      const categoryLabes = cat.label
+      if (!categoryLabes) {
+        // some datasets are using unknown vacabularies
+        // warn and drop them
+        console.warn(`No labels for category\ndataset title: ${this.#dataset.getTitle}\ndataset: ${this.#dataset.getId}\nid: ${cat.id}\nresource: <${cat.resource}>\nlabels: ${cat.label}`)
+        return []
+      }
       let preferredLabel = cat.label[lang]
       if (!preferredLabel) {
         // Try other APP_LANGUAGES
@@ -98,7 +105,7 @@ export class DcatApChV2DatasetAdapter {
         id: cat.id,
         label: preferredLabel,
       } as TagItem
-      return tagItem
+      return [tagItem]
     })
 
     return tagItems

--- a/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
+++ b/opendata.swiss/ui/app/components/dataset-detail/model/dcat-ap-ch-v2-dataset-adapter.ts
@@ -296,7 +296,7 @@ export class DcatApChV2DatasetAdapter {
       return []
     }
 
-    const ignoredNode = ['catalogRecord']
+    const ignoredNode = ['catalogRecord', 'accrualPeriodicity']
     const nodesToConsider = rootNode.filter(n => n.data).filter(n => !ignoredNode.includes(n.id))
 
     const newTableEntries: OdsTableEntry[] = []

--- a/opendata.swiss/ui/package.json
+++ b/opendata.swiss/ui/package.json
@@ -110,5 +110,8 @@
   },
   "overrides": {
     "vue-router": "^5.1.0"
+  },
+  "allowScripts": {
+    "sharp@0.32.6": true
   }
 }


### PR DESCRIPTION
"accrualPeriodicity" was displayed as a Json Object. 
- I fixed it in the Dataset Detail header
- I removed it from the "Additional information" table 

The "Additional information" table is using getPropertyTable from the piveauJS search api. I talked to Raphael from Fraunhofer. He gets the problem and is investigating how to solve it there. In the mean time I removed the property from the table.

I talked to Michele. The UI will completely change. They had a design meeting with Metadata.swiss and they will verify the design with puzzle. Then we change it. So no more UI stuff right now. 