### PR TITLE
[UI] Remove trailing slash for default Keycloak`serverUrl`

### DIFF
--- a/opendata.swiss/ui/nuxt.config.ts
+++ b/opendata.swiss/ui/nuxt.config.ts
@@ -82,7 +82,7 @@ export default defineNuxtConfig({
     },
     oauth: {
       keycloak: {
-        serverUrl: 'https://keycloak.zazukoians.org/',
+        serverUrl: 'https://keycloak.zazukoians.org',
         realm: 'lindas-next-ref',
         clientId: 'piveau-hub-ui',
         clients: {


### PR DESCRIPTION
This updates the default value for the `serverUrl` for Keycloak, to remove the trailing slash.
With the newer versions of Keycloak, having a double slash in the URL leads to an error, as it no longer normalizes the URL.

The value was already updated for ABN and REF.
This PR just updates the default value that is used.